### PR TITLE
feat: implement user registration endpoint at POST /api/register/

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -4,9 +4,11 @@ from django.conf import settings
 from django.conf.urls.static import static
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from users.views import RegisterView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/register/', RegisterView.as_view(), name='register'),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -35,6 +35,11 @@ class SignupSerializer(serializers.ModelSerializer):
             'consent_agreed', 'consent_version'
         )
 
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("A user with this email already exists.")
+        return value
+
     def validate(self, attrs):
         if attrs['password'] != attrs['confirm_password']:
             raise serializers.ValidationError({"password": "Password fields didn't match."})

--- a/backend/users/tests/test_views.py
+++ b/backend/users/tests/test_views.py
@@ -64,6 +64,29 @@ def test_signup_consent_required(api_client, db):
     assert "consent_agreed" in response.data or response.status_code == status.HTTP_400_BAD_REQUEST
 
 @pytest.mark.django_db
+def test_signup_duplicate_email(api_client, db):
+    Role.objects.get_or_create(name='Participant')
+
+    url = reverse('register')
+    payload = {
+        "username": "firstuser",
+        "full_name": "First User",
+        "email": "duplicate@example.com",
+        "password": "password123!",
+        "confirm_password": "password123!",
+        "consent_agreed": True,
+        "consent_version": "1.0"
+    }
+    response = api_client.post(url, payload)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    payload["username"] = "seconduser"
+    response = api_client.post(url, payload)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "email" in response.data
+
+
+@pytest.mark.django_db
 def test_admin_user_list(admin_client, test_user):
     url = reverse('admin_user_list')
     response = admin_client.get(url)

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,8 +1,7 @@
 from django.urls import path
-from .views import RegisterView, ProfileView, AdminUserListView, AdminUserUpdateView
+from .views import ProfileView, AdminUserListView, AdminUserUpdateView
 
 urlpatterns = [
-    path('register/', RegisterView.as_view(), name='register'),
     path('profile/', ProfileView.as_view(), name='profile'),
     path('admin/users/', AdminUserListView.as_view(), name='admin_user_list'),
     path('admin/users/<int:pk>/', AdminUserUpdateView.as_view(), name='admin_user_update'),


### PR DESCRIPTION
- Move register route from users/urls.py to core/urls.py at api/register/
- Add explicit email uniqueness validation on SignupSerializer
- Add test for duplicate email rejection

Closes #15