### PR TITLE
feat: add has_completed_baseline flag and enforce onboarding gate

### DIFF
--- a/backend/activities/tests/test_views.py
+++ b/backend/activities/tests/test_views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from activities.models import Activity
 
 @pytest.mark.django_db
-def test_activity_list_current_phase(authenticated_client, test_phase):
+def test_activity_list_current_phase(baseline_client, test_phase):
     Activity.objects.create(
         title="Test Activity",
         description="Desc",
@@ -12,12 +12,12 @@ def test_activity_list_current_phase(authenticated_client, test_phase):
         activity_type="paragraph"
     )
     url = reverse('activity_list')
-    response = authenticated_client.get(url)
+    response = baseline_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == 1
 
 @pytest.mark.django_db
-def test_submission_create(authenticated_client, test_phase):
+def test_submission_create(baseline_client, test_phase):
     activity = Activity.objects.create(
         title="Test Submission",
         description="Desc",
@@ -29,5 +29,5 @@ def test_submission_create(authenticated_client, test_phase):
         "activity": activity.id,
         "content": "My daily entry."
     }
-    response = authenticated_client.post(url, data, format='json')
+    response = baseline_client.post(url, data, format='json')
     assert response.status_code == status.HTTP_201_CREATED

--- a/backend/activities/views.py
+++ b/backend/activities/views.py
@@ -3,10 +3,11 @@ from .models import Activity, Submission
 from .serializers import ActivitySerializer, SubmissionSerializer
 from phases.models import Phase
 from django.utils import timezone
+from users.permissions import BaselineCompleted
 
 class ActivityListView(generics.ListAPIView):
     serializer_class = ActivitySerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
     def get_queryset(self):
         today = timezone.now().date()
@@ -17,14 +18,14 @@ class ActivityListView(generics.ListAPIView):
 
 class SubmissionCreateView(generics.CreateAPIView):
     serializer_class = SubmissionSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
 class UserSubmissionListView(generics.ListAPIView):
     serializer_class = SubmissionSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
     def get_queryset(self):
         return Submission.objects.filter(user=self.request.user)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -28,6 +28,22 @@ def authenticated_client(api_client, test_user):
     return api_client
 
 @pytest.fixture
+def baseline_user(db, test_group):
+    user = User.objects.create_user(
+        username="baselineuser",
+        email="baseline@example.com",
+        password="password123",
+        group=test_group,
+        has_completed_baseline=True
+    )
+    return user
+
+@pytest.fixture
+def baseline_client(api_client, baseline_user):
+    api_client.force_authenticate(user=baseline_user)
+    return api_client
+
+@pytest.fixture
 def admin_user(db):
     return User.objects.create_superuser(
         username="admin",

--- a/backend/notifications/tests/test_views.py
+++ b/backend/notifications/tests/test_views.py
@@ -3,17 +3,17 @@ from django.urls import reverse
 from rest_framework import status
 
 @pytest.mark.django_db
-def test_notification_list(authenticated_client, test_user):
+def test_notification_list(baseline_client, baseline_user):
     from notifications.models import Notification
     from django.utils import timezone
     Notification.objects.create(
-        user=test_user,
+        user=baseline_user,
         n_type='email',
         message="Test Message",
         scheduled_time=timezone.now()
     )
     url = reverse('notification_list')
-    response = authenticated_client.get(url)
+    response = baseline_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == 1
 

--- a/backend/notifications/views.py
+++ b/backend/notifications/views.py
@@ -1,10 +1,11 @@
 from rest_framework import generics, permissions
 from .models import Notification
 from .serializers import NotificationSerializer
+from users.permissions import BaselineCompleted
 
 class NotificationListView(generics.ListAPIView):
     serializer_class = NotificationSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
     def get_queryset(self):
         return Notification.objects.filter(user=self.request.user)

--- a/backend/phases/tests/test_views.py
+++ b/backend/phases/tests/test_views.py
@@ -3,15 +3,15 @@ from django.urls import reverse
 from rest_framework import status
 
 @pytest.mark.django_db
-def test_phase_list(authenticated_client, test_phase):
+def test_phase_list(baseline_client, test_phase):
     url = reverse('phase_list')
-    response = authenticated_client.get(url)
+    response = baseline_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) >= 1
 
 @pytest.mark.django_db
-def test_current_phase(authenticated_client, test_phase):
+def test_current_phase(baseline_client, test_phase):
     url = reverse('current_phase')
-    response = authenticated_client.get(url)
+    response = baseline_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert response.data['name'] == "Phase 1"

--- a/backend/phases/views.py
+++ b/backend/phases/views.py
@@ -2,15 +2,16 @@ from rest_framework import generics, permissions
 from .models import Phase
 from .serializers import PhaseSerializer
 from django.utils import timezone
+from users.permissions import BaselineCompleted
 
 class PhaseListView(generics.ListAPIView):
     queryset = Phase.objects.all()
     serializer_class = PhaseSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
 class CurrentPhaseView(generics.RetrieveAPIView):
     serializer_class = PhaseSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, BaselineCompleted,)
 
     def get_object(self):
         today = timezone.now().date()

--- a/backend/questionnaires/serializers.py
+++ b/backend/questionnaires/serializers.py
@@ -98,5 +98,7 @@ class ResponseSetSubmitSerializer(serializers.ModelSerializer):
             # 4. Trigger Group Assignment if Baseline
             if instance.questionnaire.is_baseline:
                 assign_user_to_group(instance.user)
+                instance.user.has_completed_baseline = True
+                instance.user.save(update_fields=['has_completed_baseline'])
 
         return instance

--- a/backend/questionnaires/tests/test_baseline.py
+++ b/backend/questionnaires/tests/test_baseline.py
@@ -1,0 +1,129 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from questionnaires.models import Questionnaire, Question, Option, ResponseSet
+
+
+def _create_questionnaire(is_baseline=False):
+    q = Questionnaire.objects.create(
+        title="Test Questionnaire",
+        is_baseline=is_baseline,
+        is_active=True,
+    )
+    question = Question.objects.create(
+        questionnaire=q,
+        content="How are you?",
+        type="CHOICE",
+        order=1,
+        required=True,
+    )
+    option = Option.objects.create(
+        question=question,
+        label="Good",
+        numeric_value=1,
+        order=1,
+    )
+    return q, question, option
+
+
+@pytest.mark.django_db
+def test_baseline_completion_sets_flag(authenticated_client, test_user):
+    questionnaire, question, option = _create_questionnaire(is_baseline=True)
+    response_set = ResponseSet.objects.create(
+        user=test_user,
+        questionnaire=questionnaire,
+        status='DRAFT',
+    )
+
+    url = reverse('response_set_submit', kwargs={'pk': response_set.pk})
+    payload = {
+        "responses_data": [
+            {"question_id": question.id, "selected_option_id": option.id}
+        ]
+    }
+    response = authenticated_client.post(url, payload, format='json')
+    assert response.status_code == status.HTTP_200_OK
+
+    test_user.refresh_from_db()
+    assert test_user.has_completed_baseline is True
+
+
+@pytest.mark.django_db
+def test_non_baseline_completion_does_not_set_flag(authenticated_client, test_user):
+    questionnaire, question, option = _create_questionnaire(is_baseline=False)
+    response_set = ResponseSet.objects.create(
+        user=test_user,
+        questionnaire=questionnaire,
+        status='DRAFT',
+    )
+
+    url = reverse('response_set_submit', kwargs={'pk': response_set.pk})
+    payload = {
+        "responses_data": [
+            {"question_id": question.id, "selected_option_id": option.id}
+        ]
+    }
+    response = authenticated_client.post(url, payload, format='json')
+    assert response.status_code == status.HTTP_200_OK
+
+    test_user.refresh_from_db()
+    assert test_user.has_completed_baseline is False
+
+
+@pytest.mark.django_db
+def test_incomplete_submission_not_allowed(authenticated_client, test_user):
+    """
+    A COMPLETED response_set cannot be re-submitted (get_queryset filters by DRAFT only).
+    """
+    questionnaire, question, option = _create_questionnaire(is_baseline=True)
+    response_set = ResponseSet.objects.create(
+        user=test_user,
+        questionnaire=questionnaire,
+        status='COMPLETED',
+    )
+
+    url = reverse('response_set_submit', kwargs={'pk': response_set.pk})
+    payload = {
+        "responses_data": [
+            {"question_id": question.id, "selected_option_id": option.id}
+        ]
+    }
+    response = authenticated_client.post(url, payload, format='json')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    test_user.refresh_from_db()
+    assert test_user.has_completed_baseline is False
+
+
+@pytest.mark.django_db
+def test_protected_activity_endpoint_rejects_incomplete_baseline(authenticated_client, test_user, test_phase):
+    from activities.models import Activity
+    Activity.objects.create(
+        title="Protected Activity",
+        description="Desc",
+        assigned_phase=test_phase,
+        activity_type="paragraph",
+    )
+    assert test_user.has_completed_baseline is False
+
+    url = reverse('activity_list')
+    response = authenticated_client.get(url)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_protected_phases_endpoint_rejects_incomplete_baseline(authenticated_client, test_user):
+    assert test_user.has_completed_baseline is False
+
+    url = reverse('phase_list')
+    response = authenticated_client.get(url)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_profile_returns_has_completed_baseline(authenticated_client, test_user):
+    url = reverse('profile')
+    response = authenticated_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert 'has_completed_baseline' in response.data
+    assert response.data['has_completed_baseline'] is False

--- a/backend/users/migrations/0003_user_add_has_completed_baseline.py
+++ b/backend/users/migrations/0003_user_add_has_completed_baseline.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_role_rename_registration_date_user_created_at_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='has_completed_baseline',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -37,6 +37,9 @@ class User(AbstractUser):
     def id(self):
         return self.user_id
     
+    # Onboarding state
+    has_completed_baseline = models.BooleanField(default=False)
+
     # Original consents (migrated/supported for now)
     email_consent = models.BooleanField(default=False)
     whatsapp_consent = models.BooleanField(default=False)

--- a/backend/users/permissions.py
+++ b/backend/users/permissions.py
@@ -1,0 +1,16 @@
+from rest_framework.permissions import BasePermission
+
+
+class BaselineCompleted(BasePermission):
+    """
+    Blocks access to experiment endpoints until the user has completed
+    the mandatory baseline questionnaire.
+    """
+    message = "You must complete the baseline assessment before accessing this resource."
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_completed_baseline
+        )

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -18,9 +18,10 @@ class UserSerializer(serializers.ModelSerializer):
         fields = (
             'user_id', 'username', 'full_name', 'email', 
             'whatsapp_number', 'role', 'role_name', 
-            'group', 'group_name', 'traits', 'created_at'
+            'group', 'group_name', 'traits', 'created_at',
+            'has_completed_baseline',
         )
-        read_only_fields = ('created_at',)
+        read_only_fields = ('created_at', 'has_completed_baseline',)
 
 class SignupSerializer(serializers.ModelSerializer):
     """

--- a/backend/users/tests/test_models.py
+++ b/backend/users/tests/test_models.py
@@ -1,0 +1,26 @@
+import pytest
+from users.models import User
+
+
+@pytest.mark.django_db
+def test_has_completed_baseline_default_is_false(test_user):
+    assert test_user.has_completed_baseline is False
+
+
+@pytest.mark.django_db
+def test_has_completed_baseline_updates_to_true(test_user):
+    test_user.has_completed_baseline = True
+    test_user.save(update_fields=['has_completed_baseline'])
+
+    test_user.refresh_from_db()
+    assert test_user.has_completed_baseline is True
+
+
+@pytest.mark.django_db
+def test_new_user_starts_with_false(db):
+    user = User.objects.create_user(
+        username="freshuser",
+        email="fresh@example.com",
+        password="password123"
+    )
+    assert user.has_completed_baseline is False


### PR DESCRIPTION
- Add has_completed_baseline BooleanField (default=False) to User model
- Migration 0003: add field to users_user table
- Expose has_completed_baseline (read-only) in UserSerializer / profile API
- Set flag to True in ResponseSetSubmitSerializer when baseline questionnaire is marked COMPLETED (alongside existing group assignment hook)
- Add BaselineCompleted permission class in users/permissions.py
- Apply BaselineCompleted to activities, phases, and notifications endpoints; returns 403 Forbidden until baseline is complete
- Unit tests: default False, persists True (users/tests/test_models.py)
- Integration tests: baseline completion sets flag, non-baseline does not, already-completed set returns 404, protected endpoints return 403, profile returns the field (questionnaires/tests/test_baseline.py)
- Update activity tests + conftest to use baseline_client fixture

Closes #65