### PR TITLE
Participant Submission Tracking Fix

### DIFF
--- a/backend/questionnaires/urls.py
+++ b/backend/questionnaires/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
 
     path('', QuestionnaireListView.as_view(), name='questionnaire_list'),
     path('<uuid:pk>/', QuestionnaireDetailView.as_view(), name='questionnaire_detail'),
-    path('response-sets/', ResponseSetCreateView.as_view(), name='response_set_create'),
+    path('response-sets/', ResponseSetListCreateView.as_view(), name='response_set_list_create'),
     
     # Response Management
     path('response-sets/<uuid:pk>/submit/', ResponseSetSubmitView.as_view(), name='response_set_submit'),

--- a/backend/questionnaires/urls.py
+++ b/backend/questionnaires/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import (
     QuestionnaireListView, 
     QuestionnaireDetailView, 
-    ResponseSetCreateView,
+    ResponseSetListCreateView,
     ResponseSetSubmitView,
     AdminBaselineResponseListView,
     AdminBaselineResponseDetailView

--- a/backend/questionnaires/views.py
+++ b/backend/questionnaires/views.py
@@ -19,9 +19,13 @@ class QuestionnaireDetailView(generics.RetrieveAPIView):
     serializer_class = QuestionnaireSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
-class ResponseSetCreateView(generics.CreateAPIView):
+class ResponseSetListCreateView(generics.ListCreateAPIView):
     serializer_class = ResponseSetSerializer
     permission_classes = (permissions.IsAuthenticated,)
+
+    def get_queryset(self):
+        # Users see their own response sets, ordered by most recent completion
+        return ResponseSet.objects.filter(user=self.request.user).select_related('questionnaire').order_by('-completed_at')
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)


### PR DESCRIPTION
This PR enables participants to view their historical assessment results on the main dashboard by upgrading the ResponseSet endpoint to a unified ListCreate view.