### PR TITLE
Repeat 7-day daily activities before each longitudinal assessment.

### DIFF
--- a/backend/activities/migrations/0010_submission_activity_wave.py
+++ b/backend/activities/migrations/0010_submission_activity_wave.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('activities', '0009_submission_entry_1_submission_entry_2_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submission',
+            name='activity_wave',
+            field=models.CharField(
+                choices=[
+                    ('PRE_T1', 'Pre T1'),
+                    ('PRE_T2', 'Pre T2'),
+                    ('PRE_T3', 'Pre T3'),
+                    ('PRE_T4', 'Pre T4'),
+                ],
+                db_index=True,
+                default='PRE_T1',
+                max_length=10,
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name='submission',
+            name='unique_user_experiment_day',
+        ),
+        migrations.AddConstraint(
+            model_name='submission',
+            constraint=models.UniqueConstraint(
+                fields=('user', 'activity_wave', 'experiment_day'),
+                name='unique_user_wave_experiment_day',
+            ),
+        ),
+    ]

--- a/backend/activities/models.py
+++ b/backend/activities/models.py
@@ -21,12 +21,20 @@ class Activity(models.Model):
         return self.title
 
 class Submission(models.Model):
+    ACTIVITY_WAVE_CHOICES = (
+        ('PRE_T1', 'Pre T1'),
+        ('PRE_T2', 'Pre T2'),
+        ('PRE_T3', 'Pre T3'),
+        ('PRE_T4', 'Pre T4'),
+    )
+
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='submissions')
     activity = models.ForeignKey(Activity, on_delete=models.CASCADE, related_name='submissions')
     content = models.TextField()
     entry_1 = models.TextField(blank=True, default='')
     entry_2 = models.TextField(blank=True, default='')
     entry_3 = models.TextField(blank=True, default='')
+    activity_wave = models.CharField(max_length=10, choices=ACTIVITY_WAVE_CHOICES, default='PRE_T1', db_index=True)
     experiment_day = models.PositiveIntegerField(null=True, blank=True, db_index=True)
     submission_date = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -34,8 +42,8 @@ class Submission(models.Model):
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=['user', 'experiment_day'],
-                name='unique_user_experiment_day'
+                fields=['user', 'activity_wave', 'experiment_day'],
+                name='unique_user_wave_experiment_day'
             )
         ]
         indexes = [
@@ -59,6 +67,7 @@ from django.core.cache import cache
 
 @receiver(post_save, sender=Submission)
 def invalidate_user_completion_cache(sender, instance, **kwargs):
-    """Clears the completion_rate cache for a user when they make a submission."""
-    cache_key = f"user_{instance.user_id}_completion_rate"
-    cache.delete(cache_key)
+    """Clears activity-related caches for a user when they make a submission."""
+    cache.delete(f"user_{instance.user_id}_completion_rate")
+    cache.delete(f"user_{instance.user_id}_exp_day")
+    cache.delete(f"user_{instance.user_id}_activity_state")

--- a/backend/activities/tasks.py
+++ b/backend/activities/tasks.py
@@ -17,17 +17,27 @@ def sync_user_experiment_state(user_id):
     try:
         user = User.objects.get(pk=user_id)
         
-        # 1. Sync current experiment day
+        # 1. Sync current activity state and experiment day
         if user.onboarding_completed_at:
+            from activities.timeline import get_active_activity_state
+
             now = timezone.localtime(timezone.now())
-            delta = now.date() - timezone.localtime(user.onboarding_completed_at).date()
-            exp_day = delta.days + 1
-            
-            cache_key_day = f"user_{user.user_id}_exp_day"
+            state = get_active_activity_state(user)
             tomorrow = (now + timezone.timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
             timeout = int((tomorrow - now).total_seconds())
+
+            cache_key_state = f"user_{user.user_id}_activity_state"
+            cache_key_day = f"user_{user.user_id}_exp_day"
             if timeout > 0:
-                cache.set(cache_key_day, exp_day, timeout=timeout)
+                cache.set(
+                    cache_key_state,
+                    "NONE" if state is None else state,
+                    timeout=timeout,
+                )
+                if state is not None:
+                    cache.set(cache_key_day, state.day_in_block, timeout=timeout)
+                else:
+                    cache.delete(cache_key_day)
 
         # 2. Sync submission status for today
         today_date = timezone.localdate()

--- a/backend/activities/tests/test_timeline_logic.py
+++ b/backend/activities/tests/test_timeline_logic.py
@@ -60,7 +60,7 @@ class TestTimelineAndCaching:
         tomorrow = timezone.now() + timedelta(days=1)
         with freeze_time(tomorrow):
             # Clear cache for the test to ensure fresh calculation or verify cache behavior
-            cache.delete(f"user_{user.user_id}_exp_day")
+            cache.delete(f"user_{user.user_id}_activity_state")
             
             response = api_client.get(reverse('daily-activity-current'))
             assert response.status_code == status.HTTP_200_OK
@@ -68,21 +68,23 @@ class TestTimelineAndCaching:
             assert response.data['current_day'] == 2
 
     def test_redis_caching_of_experiment_day(self, timeline_setup):
-        """Verify that the experimental day is cached in Redis."""
+        """Verify that the activity state is cached in Redis."""
         user, group, act1, act2 = timeline_setup
         
         # First call calculates and caches
         day = user.current_experiment_day
         assert day == 1
         
-        cache_key = f"user_{user.user_id}_exp_day"
-        assert cache.get(cache_key) == 1
+        cache_key = f"user_{user.user_id}_activity_state"
+        cached_state = cache.get(cache_key)
+        assert cached_state is not None
+        assert cached_state.day_in_block == 1
         
         # Manually change the date in DB but keep cache - should still return 1
         user.onboarding_completed_at = user.onboarding_completed_at - timedelta(days=5)
         user.save()
         
-        assert user.current_experiment_day == 1 # Hits cache
+        assert user.current_experiment_day == 1  # Hits cache
 
     def test_submission_persists_experiment_day(self, api_client, timeline_setup, test_phase):
         """Verify that submissions store the chronological day of the experiment."""
@@ -225,4 +227,71 @@ class TestTimelineAndCaching:
         
         # Cache should be populated
         assert cache.get(f"user_{user.user_id}_submitted_{timezone.now().date()}") is True
-        assert cache.get(f"user_{user.user_id}_exp_day") == 1
+        assert user.current_experiment_day == 1
+        assert cache.get(f"user_{user.user_id}_activity_state").wave == 'PRE_T1'
+
+
+@pytest.mark.django_db
+class TestPreAssessmentWaves:
+    """Verify the same 7-day activities repeat before T2/T3/T4."""
+
+    def test_pre_t2_wave_serves_day_one_activity(self, api_client, test_phase):
+        group = Group.objects.create(name="PreT2 Group")
+        t1_completed = timezone.now() - timedelta(days=83)
+        user = User.objects.create_user(
+            username="pret2_user", email="pret2@test.com", password="pwd",
+            group=group, has_completed_sociodemographic=True,
+            onboarding_completed_at=timezone.now() - timedelta(days=200),
+            has_completed_posttest=True,
+            posttest_completed_at=t1_completed,
+        )
+        act1 = Activity.objects.create(
+            title="Day 1 Task", description="Task 1",
+            assigned_phase=test_phase, group=group,
+            activity_type="task", day_number=1
+        )
+
+        cache.clear()
+        api_client.force_authenticate(user=user)
+        response = api_client.get(reverse('daily-activity-current'))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['id'] == act1.id
+        assert response.data['current_day'] == 1
+        assert response.data['activity_wave'] == 'PRE_T2'
+
+    def test_pre_t2_allows_resubmission_for_same_experiment_day(self, api_client, test_phase):
+        group = Group.objects.create(name="PreT2 Resubmit Group")
+        t1_completed = timezone.now() - timedelta(days=83)
+        user = User.objects.create_user(
+            username="pret2_resubmit", email="pret2r@test.com", password="pwd",
+            group=group, has_completed_sociodemographic=True,
+            onboarding_completed_at=timezone.now() - timedelta(days=200),
+            has_completed_posttest=True,
+            posttest_completed_at=t1_completed,
+        )
+        act1 = Activity.objects.create(
+            title="Day 1 Task", description="Task 1",
+            assigned_phase=test_phase, group=group,
+            activity_type="task", day_number=1
+        )
+        prior_submission = Submission.objects.create(
+            user=user, activity=act1, content="prior wave",
+            experiment_day=1, activity_wave='PRE_T1',
+        )
+        Submission.objects.filter(pk=prior_submission.pk).update(
+            submission_date=timezone.now() - timedelta(days=100),
+        )
+
+        cache.clear()
+        api_client.force_authenticate(user=user)
+        words_20 = "word " * 20
+        response = api_client.post(reverse('daily-activity-submit'), {
+            "activity": act1.id,
+            "entry_1": words_20,
+            "entry_2": words_20,
+            "entry_3": words_20,
+        }, format='json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Submission.objects.filter(user=user, activity_wave='PRE_T2', experiment_day=1).exists()

--- a/backend/activities/tests/test_views.py
+++ b/backend/activities/tests/test_views.py
@@ -26,12 +26,16 @@ def test_activity_list_current_phase(baseline_client, test_phase):
     assert len(response.data) == 1
 
 @pytest.mark.django_db
-def test_submission_create(baseline_client, test_phase):
+def test_submission_create(baseline_client, baseline_user, test_phase):
+    baseline_user.onboarding_completed_at = timezone.now()
+    baseline_user.save()
+
     activity = Activity.objects.create(
         title="Test Submission",
         description="Desc",
         assigned_phase=test_phase,
-        activity_type="paragraph"
+        activity_type="paragraph",
+        day_number=1,
     )
     url = reverse('submission_create')
     data = {
@@ -138,5 +142,5 @@ def test_full_7_day_journey(test_phase):
         cache.clear()
         response = client.get(reverse('daily-activity-current'))
         assert response.status_code == status.HTTP_200_OK
-        assert response.data.get('detail') == 'Trial period completed.'
+        assert response.data.get('detail') == 'No active activity period.'
 

--- a/backend/activities/timeline.py
+++ b/backend/activities/timeline.py
@@ -1,0 +1,174 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional, Tuple
+
+from django.utils import timezone
+
+ACTIVITY_WAVES = (
+    'PRE_T1',
+    'PRE_T2',
+    'PRE_T3',
+    'PRE_T4',
+)
+
+ACTIVITY_WAVE_CHOICES = tuple((wave, wave.replace('_', ' ')) for wave in ACTIVITY_WAVES)
+
+WAVE_LABELS = {
+    'PRE_T1': 'pre Week 1 assessment',
+    'PRE_T2': 'pre 3-month assessment',
+    'PRE_T3': 'pre 6-month assessment',
+    'PRE_T4': 'pre 1-year assessment',
+}
+
+MILESTONE_BY_WAVE = {
+    'PRE_T1': '7_DAYS',
+    'PRE_T2': '3_MONTHS',
+    'PRE_T3': '6_MONTHS',
+    'PRE_T4': '1_YEAR',
+}
+
+WAVE_PREREQUISITES = {
+    'PRE_T2': '7_DAYS',
+    'PRE_T3': '3_MONTHS',
+    'PRE_T4': '6_MONTHS',
+}
+
+ASSESSMENT_OFFSETS = {
+    'PRE_T1': 7,
+    'PRE_T2': 90,
+    'PRE_T3': 180,
+    'PRE_T4': 365,
+}
+
+BLOCK_LENGTH_DAYS = 7
+
+
+@dataclass(frozen=True)
+class ActivityState:
+    wave: str
+    day_in_block: int
+
+
+def _local_date(dt):
+    if dt is None:
+        return None
+    if timezone.is_aware(dt):
+        return timezone.localtime(dt).date()
+    return dt.date()
+
+
+def get_t1_reference_date(user):
+    """Reference datetime for T2/T3/T4 offsets (T1 completion or fallback)."""
+    from questionnaires.models import ResponseSet
+
+    t1_completed_at = user.posttest_completed_at
+    if not t1_completed_at:
+        t1_rs = ResponseSet.objects.filter(
+            user=user, status='COMPLETED', milestone='7_DAYS'
+        ).first()
+        if t1_rs:
+            t1_completed_at = t1_rs.completed_at
+
+    if t1_completed_at:
+        return t1_completed_at
+    if user.onboarding_completed_at:
+        return user.onboarding_completed_at + timedelta(days=7)
+    return None
+
+
+def _completed_milestones(user):
+    from questionnaires.models import ResponseSet
+
+    completed = set(
+        ResponseSet.objects.filter(
+            user=user,
+            status='COMPLETED',
+            milestone__isnull=False,
+            questionnaire__assessment_type='PSYCHOMETRIC',
+        ).values_list('milestone', flat=True)
+    )
+    if user.has_completed_posttest:
+        completed.add('7_DAYS')
+    return completed
+
+
+def _wave_calendar_bounds(user, wave, t1_ref) -> Optional[Tuple]:
+    """Return (block_start_date, assessment_due_date) for a wave, ignoring completion."""
+    if wave == 'PRE_T1':
+        if not user.onboarding_completed_at:
+            return None
+        block_start = _local_date(user.onboarding_completed_at)
+        assessment_due = block_start + timedelta(days=ASSESSMENT_OFFSETS['PRE_T1'])
+        return block_start, assessment_due
+
+    if not t1_ref:
+        return None
+
+    ref_date = _local_date(t1_ref)
+    assessment_due = ref_date + timedelta(days=ASSESSMENT_OFFSETS[wave])
+    block_start = assessment_due - timedelta(days=BLOCK_LENGTH_DAYS)
+    return block_start, assessment_due
+
+
+def _wave_prerequisites_met(wave, completed):
+    prereq = WAVE_PREREQUISITES.get(wave)
+    return prereq is None or prereq in completed
+
+
+def get_active_activity_state(user) -> Optional[ActivityState]:
+    """
+    Returns the active pre-assessment activity wave and day-in-block (1-7),
+    or None when the user is between waves.
+    """
+    if getattr(user, 'is_disqualified', False):
+        return None
+    if not user.onboarding_completed_at:
+        return None
+
+    today = timezone.localdate()
+    t1_ref = get_t1_reference_date(user)
+    completed = _completed_milestones(user)
+
+    for wave in ACTIVITY_WAVES:
+        milestone = MILESTONE_BY_WAVE[wave]
+        if milestone in completed:
+            continue
+        if not _wave_prerequisites_met(wave, completed):
+            continue
+
+        bounds = _wave_calendar_bounds(user, wave, t1_ref)
+        if bounds is None:
+            continue
+
+        block_start, assessment_due = bounds
+        if block_start <= today < assessment_due:
+            day_in_block = (today - block_start).days + 1
+            if 1 <= day_in_block <= BLOCK_LENGTH_DAYS:
+                return ActivityState(wave=wave, day_in_block=day_in_block)
+
+    return None
+
+
+def get_waves_for_tier3_evaluation(user):
+    """
+    Yields activity waves whose 7-day block has ended and should be evaluated
+    for the Tier 3 daily miss protocol.
+    """
+    if not user.onboarding_completed_at:
+        return
+
+    today = timezone.localdate()
+    t1_ref = get_t1_reference_date(user)
+    completed = _completed_milestones(user)
+
+    for wave in ACTIVITY_WAVES:
+        if not _wave_prerequisites_met(wave, completed):
+            continue
+
+        bounds = _wave_calendar_bounds(user, wave, t1_ref)
+        if bounds is None:
+            continue
+
+        _, assessment_due = bounds
+        if today >= assessment_due:
+            yield wave

--- a/backend/activities/views.py
+++ b/backend/activities/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.db import transaction, IntegrityError
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django.core.cache import cache
 from .models import Activity, Submission
 from .serializers import ActivitySerializer, DailySubmissionSerializer, SubmissionSerializer
+from .timeline import WAVE_LABELS
 from users.permissions import OnboardingCompleted
 from django.contrib.auth import get_user_model
 import logging
@@ -34,13 +35,16 @@ class DailyActivityViewSet(viewsets.ModelViewSet):
         Uses Redis to cache the current day and submission status for maximum performance.
         """
         user = request.user
-        current_day = user.current_experiment_day
+        activity_state = user.current_activity_state
 
-        if not current_day:
+        if not user.onboarding_completed_at:
             return Response({"detail": "Baseline not completed."}, status=status.HTTP_404_NOT_FOUND)
-        
-        if current_day > 7:
-            return Response({"detail": "Trial period completed."}, status=status.HTTP_200_OK)
+
+        if not activity_state:
+            return Response({"detail": "No active activity period."}, status=status.HTTP_200_OK)
+
+        current_day = activity_state.day_in_block
+        activity_wave = activity_state.wave
 
         activity = None
         if user.group:
@@ -74,6 +78,8 @@ class DailyActivityViewSet(viewsets.ModelViewSet):
         data = serializer.data
         data['submitted_today'] = submitted_today
         data['current_day'] = current_day
+        data['activity_wave'] = activity_wave
+        data['activity_wave_label'] = WAVE_LABELS.get(activity_wave, activity_wave)
         
         if submitted_today:
             now_local = timezone.localtime(timezone.now())
@@ -118,11 +124,21 @@ class DailyActivityViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST
                 )
             
-            current_day = user.current_experiment_day
+            activity_state = user.current_activity_state
+            if not activity_state:
+                return Response(
+                    {"detail": "No active activity period."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             serializer = DailySubmissionSerializer(data=request.data, context={'request': request})
             if serializer.is_valid():
                 try:
-                    serializer.save(user=user, experiment_day=current_day)
+                    serializer.save(
+                        user=user,
+                        experiment_day=activity_state.day_in_block,
+                        activity_wave=activity_state.wave,
+                    )
                 except IntegrityError:
                     return Response(
                         {"detail": "You have already made a submission for today or for this experiment day."}, 
@@ -169,5 +185,11 @@ class SubmissionViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         user = self.request.user
-        current_day = user.current_experiment_day
-        serializer.save(user=user, experiment_day=current_day)
+        activity_state = user.current_activity_state
+        if not activity_state:
+            raise serializers.ValidationError("No active activity period.")
+        serializer.save(
+            user=user,
+            experiment_day=activity_state.day_in_block,
+            activity_wave=activity_state.wave,
+        )

--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -161,26 +161,34 @@ def run_tier3_daily_evaluation():
     # Only active participants who completed onboarding
     users = User.objects.filter(is_active=True, has_completed_sociodemographic=True)
     
+    from activities.timeline import get_waves_for_tier3_evaluation, WAVE_LABELS
+
     tickets_created = 0
     for user in users:
-        day = user.current_experiment_day
-        if day and day >= 8:
-            # Count unique daily reflections submitted in days 1 to 7
-            sub_count = Submission.objects.filter(user=user, experiment_day__lte=7).values('experiment_day').distinct().count()
-            if sub_count <= 2:
-                # Check if a Tier 3 ticket already exists for this user to prevent duplicate creation
-                exists = SupportTicket.objects.filter(
-                    user=user, 
-                    subject__icontains="Call Protocol: High Daily Activity Miss Rate"
-                ).exists()
-                if not exists:
-                    SupportTicket.objects.create(
-                        user=user,
-                        subject="Call Protocol: High Daily Activity Miss Rate (Tier 3)",
-                        message=f"Participant {user.full_name or user.username} has reached Day 8 but only completed {sub_count} daily activities out of 7. Please place a call within 72 hours using the supportive script.",
-                        status='Open'
-                    )
-                    tickets_created += 1
+        for wave in get_waves_for_tier3_evaluation(user):
+            sub_count = Submission.objects.filter(
+                user=user, activity_wave=wave, experiment_day__lte=7
+            ).values('experiment_day').distinct().count()
+            if sub_count > 2:
+                continue
+
+            subject = f"Call Protocol: High Daily Activity Miss Rate ({wave})"
+            exists = SupportTicket.objects.filter(user=user, subject=subject).exists()
+            if exists:
+                continue
+
+            wave_label = WAVE_LABELS.get(wave, wave)
+            SupportTicket.objects.create(
+                user=user,
+                subject=subject,
+                message=(
+                    f"Participant {user.full_name or user.username} completed the {wave_label} "
+                    f"activity block with only {sub_count} daily activities out of 7. "
+                    "Please place a call within 72 hours using the supportive script."
+                ),
+                status='Open',
+            )
+            tickets_created += 1
     return f"Tier 3 evaluation completed. Created {tickets_created} tickets."
 
 

--- a/backend/notifications/tests/test_reminders.py
+++ b/backend/notifications/tests/test_reminders.py
@@ -209,7 +209,7 @@ class TestMissedDayProtocol:
             group=test_group, has_completed_sociodemographic=True,
             onboarding_completed_at=timezone.now() - timedelta(days=7)
         )
-        assert user.current_experiment_day == 8
+        assert user.current_experiment_day is None
 
         # With 0 submissions (<= 2), the user should trigger Tier 3 Call Protocol
         result = run_tier3_daily_evaluation()
@@ -218,7 +218,7 @@ class TestMissedDayProtocol:
         ticket = SupportTicket.objects.filter(user=user).first()
         assert ticket is not None
         assert "Call Protocol" in ticket.subject
-        assert "Tier 3" in ticket.subject
+        assert "(PRE_T1)" in ticket.subject
         assert ticket.status == 'Open'
 
     def test_tier4_assessment_milestone_expiration(self, test_group):

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -71,42 +71,55 @@ class User(AbstractUser):
         return self.username
 
     @property
-    def current_experiment_day(self):
+    def current_activity_state(self):
         """
-        Calculates the user's current day in the experiment (1-indexed).
-        Caches the result in Redis until next midnight to optimize speed.
+        Returns the active pre-assessment activity wave state, cached until midnight.
         """
-        if getattr(self, 'is_disqualified', False):
+        if getattr(self, 'is_disqualified', False) or not self.onboarding_completed_at:
             return None
 
-        if not self.onboarding_completed_at:
-            return None
+        cache_key = f"user_{self.user_id}_activity_state"
+        cached_state = cache.get(cache_key)
+        if cached_state is not None:
+            return None if cached_state == "NONE" else cached_state
 
-        cache_key = f"user_{self.user_id}_exp_day"
-        cached_day = cache.get(cache_key)
-        if cached_day is not None:
-            return cached_day
+        from activities.timeline import get_active_activity_state
 
+        state = get_active_activity_state(self)
         now = timezone.now()
-        onboard_date = timezone.localtime(self.onboarding_completed_at).date() if timezone.is_aware(self.onboarding_completed_at) else self.onboarding_completed_at.date()
-        today_date = timezone.localdate() if timezone.is_aware(now) else now.date()
-        delta = today_date - onboard_date
-        exp_day = delta.days + 1
-
-        # Cache until midnight
         tomorrow = (now + timezone.timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
         seconds_until_midnight = int((tomorrow - now).total_seconds())
         if seconds_until_midnight > 0:
-            cache.set(cache_key, exp_day, timeout=seconds_until_midnight)
+            cache.set(
+                cache_key,
+                "NONE" if state is None else state,
+                timeout=seconds_until_midnight,
+            )
+        return state
 
-        return exp_day
+    @property
+    def current_activity_wave(self):
+        state = self.current_activity_state
+        return state.wave if state else None
+
+    @property
+    def current_experiment_day(self):
+        """
+        Day within the current 7-day pre-assessment activity block (1-7), or None
+        when the user is between waves.
+        """
+        state = self.current_activity_state
+        return state.day_in_block if state else None
 
     @property
     def is_posttest_due(self):
-        """Returns True if the user has reached Day 8+ (7 days after onboarding completion) and hasn't completed the post-test."""
+        """Returns True once the PRE_T1 activity block has ended and T1 is still outstanding."""
         if not self.has_completed_sociodemographic or self.has_completed_posttest:
             return False
-        return self.current_experiment_day is not None and self.current_experiment_day >= 8
+        if not self.onboarding_completed_at:
+            return False
+        due_date = self.onboarding_completed_at + timezone.timedelta(days=7)
+        return timezone.now() >= due_date
 
     @property
     def is_t2_due(self):
@@ -233,11 +246,15 @@ class User(AbstractUser):
         if cached_rate is not None:
             return cached_rate
 
-        # Max out at 7 days for calculation
         effective_day = min(current_day, 7)
-        
+        wave = self.current_activity_wave
+        if not wave:
+            return 0
+
         from activities.models import Submission
-        submissions_count = Submission.objects.filter(user=self).values('experiment_day').distinct().count()
+        submissions_count = Submission.objects.filter(
+            user=self, activity_wave=wave
+        ).values('experiment_day').distinct().count()
         
         # Avoid division by zero
         rate = int((submissions_count / effective_day) * 100) if effective_day > 0 else 0
@@ -255,16 +272,13 @@ class User(AbstractUser):
         during their active week (Days 1 to 7) and has not yet gotten back on track.
         """
         current_day = self.current_experiment_day
-        if not current_day or not self.onboarding_completed_at:
-            return False
-
-        if current_day > 7:
+        wave = self.current_activity_wave
+        if not current_day or not wave or not self.onboarding_completed_at:
             return False
 
         from activities.models import Submission
-        # Find which days the user has submitted daily activities
         submitted_days = set(
-            Submission.objects.filter(user=self, experiment_day__lte=7)
+            Submission.objects.filter(user=self, activity_wave=wave, experiment_day__lte=7)
             .values_list('experiment_day', flat=True)
         )
 

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -13,6 +13,8 @@ class UserSerializer(serializers.ModelSerializer):
     group_name = serializers.ReadOnlyField(source='group.name')
     role_name = serializers.ReadOnlyField(source='role.name')
     due_milestone = serializers.CharField(source='get_due_milestone', read_only=True)
+    current_experiment_day = serializers.IntegerField(read_only=True, allow_null=True)
+    current_activity_wave = serializers.CharField(read_only=True, allow_null=True)
 
     class Meta:
         model = User
@@ -22,12 +24,14 @@ class UserSerializer(serializers.ModelSerializer):
             'group', 'group_name', 'traits', 'created_at',
             'has_completed_sociodemographic',
             'has_completed_posttest', 'is_posttest_due', 'due_milestone',
+            'current_experiment_day', 'current_activity_wave',
             'completion_rate', 'has_consecutive_misses', 'consecutive_misses_message',
             'has_two_consecutive_missed_waves', 'is_disqualified',
         )
         read_only_fields = (
             'created_at', 'has_completed_sociodemographic', 'has_completed_posttest',
-            'is_posttest_due', 'due_milestone', 'completion_rate', 'has_consecutive_misses',
+            'is_posttest_due', 'due_milestone', 'current_experiment_day', 'current_activity_wave',
+            'completion_rate', 'has_consecutive_misses',
             'consecutive_misses_message', 'has_two_consecutive_missed_waves', 'is_disqualified',
         )
 

--- a/backend/users/tests/test_models.py
+++ b/backend/users/tests/test_models.py
@@ -71,12 +71,12 @@ def test_current_experiment_day_caching(test_user):
     test_user.onboarding_completed_at = timezone.now() - timezone.timedelta(days=1) # Day 2
     test_user.save()
 
-    cache_key = f"user_{test_user.user_id}_exp_day"
+    cache_key = f"user_{test_user.user_id}_activity_state"
     cache.delete(cache_key)
 
     day = test_user.current_experiment_day
     assert day == 2
-    assert cache.get(cache_key) == 2
+    assert cache.get(cache_key).day_in_block == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Participants now cycle through the same Day 1-7 prompts in PRE_T1 through PRE_T4 windows aligned to T1-T4 due dates, with wave-scoped submissions and updated tier-3 miss detection.
closes #159 