### PR TITLE
Add admin permanent user deletion with typed confirmation guardrail.

### DIFF
--- a/backend/users/tests/test_admin_delete_user.py
+++ b/backend/users/tests/test_admin_delete_user.py
@@ -1,0 +1,102 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from activities.models import Activity, Submission
+from groups.models import Group
+from phases.models import Phase
+from questionnaires.models import Questionnaire, ResponseSet
+from support.models import SupportTicket
+from users.models import User, UserConsent
+
+
+@pytest.fixture
+def participant_with_data(db, test_group, test_phase):
+    user = User.objects.create_user(
+        username="delete_me",
+        email="delete_me@example.com",
+        password="password123",
+        group=test_group,
+        full_name="Delete Me",
+    )
+    UserConsent.objects.create(user=user, agreed=True, consent_version="1.0")
+
+    activity = Activity.objects.create(
+        title="Daily Task",
+        description="Prompt",
+        assigned_phase=test_phase,
+        group=test_group,
+        activity_type="paragraph",
+        day_number=1,
+    )
+    Submission.objects.create(user=user, activity=activity, content="entry", experiment_day=1)
+
+    questionnaire = Questionnaire.objects.create(title="Battery", assessment_type="PSYCHOMETRIC")
+    ResponseSet.objects.create(
+        user=user,
+        questionnaire=questionnaire,
+        status="COMPLETED",
+        milestone="SIGNUP",
+    )
+
+    SupportTicket.objects.create(user=user, subject="Help", message="Need support", status="Open")
+    return user
+
+
+@pytest.mark.django_db
+def test_admin_delete_user_requires_confirmation(admin_client, participant_with_data):
+    url = reverse("admin_user_delete", kwargs={"pk": participant_with_data.pk})
+
+    response = admin_client.post(url, {"confirmation": "wrong phrase"}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert User.objects.filter(pk=participant_with_data.pk).exists()
+
+
+@pytest.mark.django_db
+def test_admin_delete_user_success(admin_client, participant_with_data):
+    url = reverse("admin_user_delete", kwargs={"pk": participant_with_data.pk})
+    user_id = participant_with_data.pk
+
+    response = admin_client.post(url, {"confirmation": "Confirm Delete"}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not User.objects.filter(pk=user_id).exists()
+    assert Submission.objects.filter(user_id=user_id).count() == 0
+    assert ResponseSet.objects.filter(user_id=user_id).count() == 0
+    assert SupportTicket.objects.filter(user_id=user_id).count() == 0
+    assert UserConsent.objects.filter(user_id=user_id).count() == 0
+
+
+@pytest.mark.django_db
+def test_admin_delete_user_forbidden_for_non_admin(authenticated_client, participant_with_data):
+    url = reverse("admin_user_delete", kwargs={"pk": participant_with_data.pk})
+
+    response = authenticated_client.post(url, {"confirmation": "Confirm Delete"}, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert User.objects.filter(pk=participant_with_data.pk).exists()
+
+
+@pytest.mark.django_db
+def test_admin_cannot_delete_self(admin_client, admin_user):
+    url = reverse("admin_user_delete", kwargs={"pk": admin_user.pk})
+
+    response = admin_client.post(url, {"confirmation": "Confirm Delete"}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert User.objects.filter(pk=admin_user.pk).exists()
+
+
+@pytest.mark.django_db
+def test_admin_cannot_delete_superuser(admin_client, db):
+    other_admin = User.objects.create_superuser(
+        username="other_admin",
+        email="other_admin@example.com",
+        password="adminpassword",
+    )
+    url = reverse("admin_user_delete", kwargs={"pk": other_admin.pk})
+
+    response = admin_client.post(url, {"confirmation": "Confirm Delete"}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert User.objects.filter(pk=other_admin.pk).exists()

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import ProfileView, AdminUserListView, AdminUserUpdateView
+from .views import ProfileView, AdminUserListView, AdminUserUpdateView, AdminUserDeleteView
 
 urlpatterns = [
     path('profile/', ProfileView.as_view(), name='profile'),
     path('admin/users/', AdminUserListView.as_view(), name='admin_user_list'),
     path('admin/users/<int:pk>/', AdminUserUpdateView.as_view(), name='admin_user_update'),
+    path('admin/users/<int:pk>/delete/', AdminUserDeleteView.as_view(), name='admin_user_delete'),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -27,6 +27,48 @@ class AdminUserUpdateView(generics.UpdateAPIView):
     serializer_class = UserSerializer
     permission_classes = (permissions.IsAdminUser,)
 
+ADMIN_DELETE_CONFIRMATION = "Confirm Delete"
+
+
+class AdminUserDeleteView(APIView):
+    permission_classes = (permissions.IsAdminUser,)
+
+    def post(self, request, pk):
+        confirmation = (request.data.get("confirmation") or "").strip()
+        if confirmation != ADMIN_DELETE_CONFIRMATION:
+            return Response(
+                {
+                    "detail": (
+                        f'You must type "{ADMIN_DELETE_CONFIRMATION}" exactly to permanently delete this user.'
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            user = User.objects.get(pk=pk)
+        except User.DoesNotExist:
+            return Response({"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        if user.pk == request.user.pk:
+            return Response(
+                {"detail": "You cannot delete your own account."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if user.is_superuser:
+            return Response(
+                {"detail": "Admin accounts cannot be deleted through this action."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        username = user.username
+        user.delete()
+        return Response(
+            {"detail": f'User "{username}" permanently deleted.'},
+            status=status.HTTP_200_OK,
+        )
+
 class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
 

--- a/frontend/src/components/Admin/DeleteUserModal.tsx
+++ b/frontend/src/components/Admin/DeleteUserModal.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, Loader2, Trash2, X } from 'lucide-react';
+
+const CONFIRMATION_PHRASE = 'Confirm Delete';
+
+interface DeleteUserModalProps {
+  isOpen: boolean;
+  username: string;
+  fullName?: string;
+  deleting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteUserModal: React.FC<DeleteUserModalProps> = ({
+  isOpen,
+  username,
+  fullName,
+  deleting,
+  error,
+  onClose,
+  onConfirm,
+}) => {
+  const [confirmation, setConfirmation] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setConfirmation('');
+    }
+  }, [isOpen, username]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const canDelete = confirmation === CONFIRMATION_PHRASE && !deleting;
+  const displayName = fullName || username;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40">
+      <div className="bg-white border border-zinc-200 rounded-xl shadow-xl max-w-lg w-full p-6 space-y-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-lg bg-red-50 text-red-600 flex items-center justify-center shrink-0">
+              <AlertTriangle size={20} />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900">Permanently Delete User</h2>
+              <p className="text-sm text-zinc-500 mt-1">
+                This will permanently remove <strong className="text-zinc-800">{displayName}</strong> (@{username}) and all related data, including submissions, assessments, support tickets, and notifications. This cannot be undone.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={deleting}
+            className="p-2 text-zinc-400 hover:text-zinc-700 transition-colors disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="delete-confirmation" className="text-sm font-medium text-zinc-700">
+            Type <span className="font-mono text-red-700">{CONFIRMATION_PHRASE}</span> to confirm
+          </label>
+          <input
+            id="delete-confirmation"
+            type="text"
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            placeholder={CONFIRMATION_PHRASE}
+            className="input-minimal"
+            autoComplete="off"
+            disabled={deleting}
+          />
+        </div>
+
+        {error && (
+          <div className="p-3 rounded-lg bg-red-50 border border-red-100 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={deleting}
+            className="px-4 py-2.5 rounded-lg border border-zinc-200 text-zinc-700 text-sm font-medium hover:bg-zinc-50 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={!canDelete}
+            className="px-4 py-2.5 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {deleting ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+            Delete User
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteUserModal;

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -9,9 +9,11 @@ import {
   Edit3, 
   Save, 
   X,
-  ArrowLeft
+  ArrowLeft,
+  Trash2
 } from 'lucide-react';
-import { getGroupDetail, updateGroup } from '../services/api';
+import { getGroupDetail, updateGroup, usersApi } from '../services/api';
+import DeleteUserModal from '../components/Admin/DeleteUserModal';
 
 interface Participant {
   user_id: number;
@@ -42,6 +44,9 @@ const GroupDetailPage: React.FC = () => {
   
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState({ name: '', description: '' });
+  const [deleteTarget, setDeleteTarget] = useState<Participant | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const fetchDetail = async () => {
     if (!id) return;
@@ -76,6 +81,25 @@ const GroupDetailPage: React.FC = () => {
     } catch (err) {
       console.error('Failed to update group', err);
       setError('Failed to save changes. Please try again.');
+    }
+  };
+
+  const handleDeleteUser = async () => {
+    if (!deleteTarget || !group) return;
+    setDeleteLoading(true);
+    setDeleteError(null);
+    try {
+      await usersApi.deleteUser(deleteTarget.user_id, 'Confirm Delete');
+      setGroup({
+        ...group,
+        participants: group.participants.filter((p) => p.user_id !== deleteTarget.user_id),
+        member_count: Math.max(0, group.member_count - 1),
+      });
+      setDeleteTarget(null);
+    } catch (err: any) {
+      setDeleteError(err.response?.data?.detail || 'Failed to delete user. Please try again.');
+    } finally {
+      setDeleteLoading(false);
     }
   };
 
@@ -190,6 +214,7 @@ const GroupDetailPage: React.FC = () => {
                     <th className="px-6 py-4 text-xs font-semibold text-zinc-500 uppercase tracking-wider">Day Number</th>
                     <th className="px-6 py-4 text-xs font-semibold text-zinc-500 uppercase tracking-wider">Daily Submissions</th>
                     <th className="px-6 py-4 text-xs font-semibold text-zinc-500 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-4 text-xs font-semibold text-zinc-500 uppercase tracking-wider text-right">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-zinc-100">
@@ -236,11 +261,24 @@ const GroupDetailPage: React.FC = () => {
                            </div>
                         )}
                       </td>
+                      <td className="px-6 py-4 text-right">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteError(null);
+                            setDeleteTarget(p);
+                          }}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-red-200 text-red-700 text-xs font-semibold hover:bg-red-50 transition-colors"
+                        >
+                          <Trash2 size={14} />
+                          Delete
+                        </button>
+                      </td>
                     </tr>
                   ))}
                   {group.participants.length === 0 && (
                     <tr>
-                      <td colSpan={4} className="px-6 py-16 text-center text-zinc-400 italic text-sm">
+                      <td colSpan={5} className="px-6 py-16 text-center text-zinc-400 italic text-sm">
                          No participants assigned to this experimental segment.
                       </td>
                     </tr>
@@ -250,6 +288,21 @@ const GroupDetailPage: React.FC = () => {
             </div>
           </div>
       </div>
+
+      <DeleteUserModal
+        isOpen={Boolean(deleteTarget)}
+        username={deleteTarget?.username || ''}
+        fullName={deleteTarget?.full_name}
+        deleting={deleteLoading}
+        error={deleteError}
+        onClose={() => {
+          if (!deleteLoading) {
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }
+        }}
+        onConfirm={handleDeleteUser}
+      />
     </div>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -135,4 +135,9 @@ export const getGroups = groupsApi.list;
 export const getGroupDetail = groupsApi.getDetail;
 export const updateGroup = groupsApi.update;
 
+export const usersApi = {
+  deleteUser: (userId: number, confirmation: string) =>
+    api.post(`/users/admin/users/${userId}/delete/`, { confirmation }),
+};
+
 export default api;

--- a/frontend/src/test/DeleteUserModal.test.tsx
+++ b/frontend/src/test/DeleteUserModal.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeleteUserModal from '../components/Admin/DeleteUserModal';
+
+describe('DeleteUserModal', () => {
+  it('enables delete only when the exact confirmation phrase is entered', () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteUserModal
+        isOpen
+        username="tester"
+        fullName="Test User"
+        deleting={false}
+        error={null}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /Delete User/i });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Type/i), { target: { value: 'Confirm Delete' } });
+    expect(deleteButton).not.toBeDisabled();
+
+    fireEvent.click(deleteButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Admins can delete participants from the group roster after typing Confirm Delete, with cascade removal of all related records and protections against self or superuser deletion.