### PR TITLE
Restore SCALE draft responses as numeric values

### DIFF
--- a/frontend/src/pages/QuestionnairePage.tsx
+++ b/frontend/src/pages/QuestionnairePage.tsx
@@ -84,10 +84,43 @@ const QuestionnairePage: React.FC = () => {
         // Restore previous draft responses if they exist
         if (rsRes.data.responses && Array.isArray(rsRes.data.responses)) {
           const restored: Record<string, any> = {};
+          const qs = qRes.data.questions || [];
           rsRes.data.responses.forEach((r: any) => {
-            restored[r.question] = r.selected_option || r.text_value;
+            const questionObj = qs.find((q: any) => q.id === r.question);
+            if (questionObj && questionObj.type === 'SCALE') {
+              const selectedOpt = questionObj.options?.find((o: any) => o.id === r.selected_option);
+              if (selectedOpt) {
+                restored[r.question] = selectedOpt.numeric_value;
+              } else {
+                restored[r.question] = r.selected_option;
+              }
+            } else {
+              restored[r.question] = r.selected_option || r.text_value;
+            }
           });
           setResponses(restored);
+
+          // Auto-advance to the last scale group that has at least one saved answer,
+          // so the user is dropped back at the right place without having to click Next.
+          const groups: { name: string; questions: any[] }[] = [];
+          const groupMap: Record<string, any[]> = {};
+          qs.forEach((q: any) => {
+            const match = q.content.match(/^\[(.*?)\]/);
+            const scale = match ? match[1] : 'General';
+            if (!groupMap[scale]) {
+              groupMap[scale] = [];
+              groups.push({ name: scale, questions: groupMap[scale] });
+            }
+            groupMap[scale].push(q);
+          });
+          let resumeIndex = 0;
+          for (let i = 0; i < groups.length; i++) {
+            const groupHasAnswer = groups[i].questions.some(
+              (q: any) => restored[q.id] !== undefined && restored[q.id] !== null && restored[q.id] !== ''
+            );
+            if (groupHasAnswer) resumeIndex = i;
+          }
+          setCurrentIndex(resumeIndex);
         }
       } catch (err: any) {
         const detail = err.response?.data?.detail;
@@ -156,6 +189,57 @@ const QuestionnairePage: React.FC = () => {
     });
   }, [currentScaleGroup, responses]);
 
+  /**
+   * Build a save payload that only includes questions that have been answered.
+   * This is critical: the backend does delete+bulk_create on every save, so sending
+   * null for unanswered questions would wipe out previously-saved answers.
+   */
+  const buildAnsweredPayload = (currentResponses: Record<string, any>) => {
+    return questions
+      .filter((q: any) => {
+        const val = currentResponses[q.id];
+        return val !== undefined && val !== null && val !== '';
+      })
+      .map((q: any) => {
+        const response = currentResponses[q.id];
+        const base = { question_id: q.id };
+        if (q.type === 'TEXT') {
+          return { ...base, text_value: String(response) };
+        } else if (q.type === 'SCALE') {
+          const selectedOpt = q.options.find((o: any) => o.numeric_value === response);
+          return { ...base, selected_option_id: selectedOpt?.id || null };
+        } else if (q.type === 'CHOICE') {
+          return { ...base, selected_option_id: response || null };
+        }
+        return base;
+      });
+  };
+
+  /**
+   * Immediately flush all answered responses to the server (no debounce).
+   * Called explicitly on Next click to guarantee current-scale answers are
+   * persisted before the user advances, even if no answer was changed.
+   */
+  const saveDraftNow = async (currentResponses: Record<string, any>) => {
+    if (!responseSetId) return;
+    // Cancel any pending debounced save — this one supersedes it.
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    const payload = buildAnsweredPayload(currentResponses);
+    if (payload.length === 0) return;
+    setIsSaving(true);
+    try {
+      await questionnairesApi.saveDraftResponseSet(responseSetId, payload);
+      setLastSaved(new Date());
+    } catch (err) {
+      console.error('Failed to flush draft:', err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const handleResponseChange = (questionId: string, value: any) => {
     let newResponses = {
       ...responses,
@@ -181,33 +265,19 @@ const QuestionnairePage: React.FC = () => {
 
     setResponses(newResponses);
 
+    // Debounced autosave — only sends answered questions.
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
     }
-
     setIsSaving(true);
     saveTimeoutRef.current = setTimeout(async () => {
       if (!responseSetId) return;
       try {
-        const payload = questions.map((q: any) => {
-          const response = newResponses[q.id];
-          const base = { question_id: q.id };
-
-          if (q.type === 'TEXT') {
-            return { ...base, text_value: response || "" };
-          } else if (q.type === 'SCALE' || q.type === 'CHOICE') {
-            if (q.type === 'SCALE') {
-              const selectedOpt = q.options.find((o: any) => o.numeric_value === response);
-              return { ...base, selected_option_id: selectedOpt?.id || null };
-            } else {
-              return { ...base, selected_option_id: response || null };
-            }
-          }
-          return base;
-        });
-
-        await questionnairesApi.saveDraftResponseSet(responseSetId, payload);
-        setLastSaved(new Date());
+        const payload = buildAnsweredPayload(newResponses);
+        if (payload.length > 0) {
+          await questionnairesApi.saveDraftResponseSet(responseSetId, payload);
+          setLastSaved(new Date());
+        }
       } catch (err) {
         console.error('Failed to auto-save:', err);
       } finally {
@@ -283,8 +353,12 @@ const QuestionnairePage: React.FC = () => {
     proceedNext();
   };
 
-  const proceedNext = () => {
+  const proceedNext = async () => {
     if (currentIndex < scaleGroups.length - 1) {
+      // Flush all answered responses to the server before advancing.
+      // This guarantees the current scale's answers are persisted even
+      // if no answer was changed (so the debounced autosave didn't fire).
+      await saveDraftNow(responses);
       setCurrentIndex(prev => prev + 1);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {

--- a/frontend/src/test/QuestionnairePage.test.tsx
+++ b/frontend/src/test/QuestionnairePage.test.tsx
@@ -320,5 +320,110 @@ describe('QuestionnairePage Scale-Grouped Paging and Autosave', () => {
       expect(screen.getByText('Scale 2 / 2')).toBeInTheDocument();
     });
   });
+
+  it('auto-saves only answered questions (filtered payload, does not send nulls)', async () => {
+    (questionnairesApi.saveDraftResponseSet as any).mockResolvedValue({ data: { success: true } });
+
+    render(
+      <MemoryRouter initialEntries={['/questionnaires/q-1']}>
+        <Routes>
+          <Route path="/questionnaires/:id" element={<QuestionnairePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Longitudinal Scales')).toBeInTheDocument();
+    });
+
+    // Click '0' response only for question 1 (leaving ques-2 unanswered)
+    const buttons = screen.getAllByRole('button');
+    const zeroButton = buttons.find(b => b.textContent?.includes('0') && !b.textContent.includes('10'));
+    fireEvent.click(zeroButton!);
+
+    // Wait for debounce
+    await delay(600);
+
+    expect(questionnairesApi.saveDraftResponseSet).toHaveBeenCalledTimes(1);
+
+    // The payload must NOT include ques-2 (unanswered) — only ques-1
+    const [, payload] = (questionnairesApi.saveDraftResponseSet as any).mock.calls[0];
+    const questionIds = payload.map((p: any) => p.question_id);
+    expect(questionIds).toContain('ques-1');
+    expect(questionIds).not.toContain('ques-2');
+  });
+
+  it('auto-advances to the last answered scale group when resuming a draft session', async () => {
+    // Simulate a response set that already has PHQ-9 (scale 2) answers saved
+    const draftResponseSet = {
+      id: 'rs-123',
+      responses: [
+        { question: 'ques-1', selected_option: 'opt-0',  text_value: null },
+        { question: 'ques-2', selected_option: 'opt-0',  text_value: null },
+        { question: 'ques-3', selected_option: 'opt-p0', text_value: null },
+      ]
+    };
+    (questionnairesApi.createResponseSet as any).mockResolvedValue({ data: draftResponseSet });
+
+    render(
+      <MemoryRouter initialEntries={['/questionnaires/q-1']}>
+        <Routes>
+          <Route path="/questionnaires/:id" element={<QuestionnairePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Should auto-advance to Scale 2 (PHQ-9), not Scale 1 (PERMA)
+    await waitFor(() => {
+      expect(screen.getByText('Scale 2 / 2')).toBeInTheDocument();
+      // PHQ-9 question should be visible
+      expect(screen.getByText('Feeling down, depressed.')).toBeInTheDocument();
+      // PERMA questions should NOT be visible
+      expect(screen.queryByText('How happy are you?')).not.toBeInTheDocument();
+    });
+  });
+
+  it('correctly maps restored SCALE responses to numeric values so they are not saved as null on next save', async () => {
+    const draftResponseSet = {
+      id: 'rs-123',
+      responses: [
+        { question: 'ques-1', selected_option: 'opt-0',  text_value: null },
+        { question: 'ques-2', selected_option: 'opt-0',  text_value: null },
+      ]
+    };
+    (questionnairesApi.createResponseSet as any).mockResolvedValue({ data: draftResponseSet });
+    (questionnairesApi.saveDraftResponseSet as any).mockResolvedValue({ data: { success: true } });
+
+    render(
+      <MemoryRouter initialEntries={['/questionnaires/q-1']}>
+        <Routes>
+          <Route path="/questionnaires/:id" element={<QuestionnairePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the questionnaire to load
+    await waitFor(() => {
+      expect(screen.getByText('Longitudinal Scales')).toBeInTheDocument();
+    });
+
+    // Since both ques-1 and ques-2 are restored, the Continue button should be enabled immediately
+    const continueBtn = screen.getByRole('button', { name: /Continue/i });
+    expect(continueBtn).not.toBeDisabled();
+
+    // Click Continue to trigger saveDraftNow
+    fireEvent.click(continueBtn);
+
+    // Verify saveDraftResponseSet is called with the correct option IDs, not nulls!
+    await waitFor(() => {
+      expect(questionnairesApi.saveDraftResponseSet).toHaveBeenCalledWith(
+        'rs-123',
+        expect.arrayContaining([
+          { question_id: 'ques-1', selected_option_id: 'opt-0' },
+          { question_id: 'ques-2', selected_option_id: 'opt-0' },
+        ])
+      );
+    });
+  });
 });
 


### PR DESCRIPTION
This PR fixes the issue where SCALE draft responses were restored as option UUID strings rather than numeric values, causing subsequent page transitions or autosaves to save them as null and wipe out earlier responses.