### PR TITLE
Add doc-style bilingual booster phase emails (E3-E12).

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -274,10 +274,13 @@ if 'test' in sys.argv or 'pytest' in sys.modules:
 # Celery Beat Schedule
 from celery.schedules import crontab
 CELERY_BEAT_SCHEDULE = {
-    'daily-morning-reminder': {
-        'task': 'notifications.tasks.check_and_send_daily_reminders',
+    'booster-daily-nudge': {
+        'task': 'emails.booster_tasks.send_booster_daily_nudges',
         'schedule': crontab(hour=9, minute=0),
-        'args': ('morning',),
+    },
+    'booster-phase-invite': {
+        'task': 'emails.booster_tasks.send_booster_phase_invites',
+        'schedule': crontab(hour=9, minute=15),
     },
     'daily-evening-reminder': {
         'task': 'notifications.tasks.check_and_send_daily_reminders',

--- a/backend/emails/booster_content.py
+++ b/backend/emails/booster_content.py
@@ -1,0 +1,231 @@
+"""E3–E12 booster / phase email copy from Psycheversity_Participant_Emails_Bilingual.docx."""
+
+DAILY_NUDGE_EMAIL = {
+    'subject_en': "Day {day_in_phase} of Phase {phase} : today's writing exercise",
+    'subject_ur': 'مرحلہ {phase} کا دن {day_in_phase} : آج کی تحریری مشق',
+    'title_en': "Today's Writing Exercise",
+    'title_ur': 'آج کی تحریری مشق',
+    'lead_en': (
+        'Dear {first_name}, here is Day {day_in_phase} of Phase {phase}. '
+        "Tap below to complete today's short writing exercise."
+    ),
+    'lead_ur': (
+        'محترم {first_name}، یہ مرحلہ {phase} کا دن {day_in_phase} ہے۔ '
+        'آج کی مختصر تحریری مشق مکمل کرنے کے لیے نیچے دبائیں۔'
+    ),
+    'button_en': "Start today's exercise",
+    'button_ur': 'آج کی مشق شروع کریں',
+}
+
+PHASE_1_COMPLETE_EMAIL = {
+    'subject_en': 'Phase 1 complete : thank you',
+    'subject_ur': 'مرحلہ 1 مکمل : شکریہ',
+    'title_en': 'Phase 1 Complete',
+    'title_ur': 'مرحلہ 1 مکمل',
+    'paragraphs_en': [
+        'You have completed Phase 1. Thank you for your effort over these seven days.',
+        (
+            'There is now a short break. We will contact you again before the end of the month '
+            'to begin the next phase.'
+        ),
+        'Nothing is needed from you until then.',
+    ],
+    'paragraphs_ur': [
+        'آپ نے مرحلہ 1 مکمل کر لیا ہے۔ ان سات دنوں میں آپ کی محنت کا شکریہ۔',
+        'اب ایک مختصر وقفہ ہے۔ اگلے مرحلے کے لیے ہم مہینے کے اختتام سے پہلے دوبارہ رابطہ کریں گے۔',
+        'تب تک آپ سے کسی چیز کی ضرورت نہیں۔',
+    ],
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+
+PHASE_2_COMPLETE_EMAIL = {
+    'subject_en': 'Phase 2 complete : thank you',
+    'subject_ur': 'مرحلہ 2 مکمل : شکریہ',
+    'title_en': 'Phase 2 Complete',
+    'title_ur': 'مرحلہ 2 مکمل',
+    'paragraphs_en': [
+        'You have completed Phase 2. Thank you for staying with the study.',
+        'There is now a longer break before the next phase. We will contact you again when it is time to continue.',
+    ],
+    'paragraphs_ur': [
+        'آپ نے مرحلہ 2 مکمل کر لیا ہے۔ تحقیق کے ساتھ جُڑے رہنے کا شکریہ۔',
+        'اگلے مرحلے سے پہلے اب ایک قدرے طویل وقفہ ہے۔ جب جاری رکھنے کا وقت ہوگا تو ہم دوبارہ رابطہ کریں گے۔',
+    ],
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+
+PHASE_INVITE_TEMPLATES = {
+    'phase_2': {
+        'subject_en': 'Your next phase starts soon',
+        'subject_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'title_en': 'Your Next Phase Starts Soon',
+        'title_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'paragraphs_en': [
+            'Your next phase is about to begin. In a few days you will restart the seven-day writing exercise.',
+            (
+                'These short sessions are the heart of the study, and your steady participation makes the '
+                'findings meaningful. We hope you will continue with us.'
+            ),
+            'We will send your daily link once the phase begins.',
+        ],
+        'paragraphs_ur': [
+            'آپ کا اگلا مرحلہ جلد شروع ہونے والا ہے۔ چند دنوں میں آپ سات روزہ تحریری مشق دوبارہ شروع کریں گے۔',
+            (
+                'یہ مختصر نشستیں اس تحقیق کا اصل حصہ ہیں، اور آپ کی مسلسل شرکت نتائج کو بامعنی بناتی ہے۔ '
+                'ہمیں اُمید ہے کہ آپ ہمارے ساتھ جاری رکھیں گے۔'
+            ),
+            'مرحلہ شروع ہوتے ہی ہم آپ کو روزانہ کا لنک بھیجیں گے۔',
+        ],
+    },
+    'phase_3': {
+        'subject_en': 'Your next phase starts soon',
+        'subject_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'title_en': 'Your Next Phase Starts Soon',
+        'title_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'paragraphs_en': [
+            'Your next phase begins in a few days, with another seven-day writing exercise.',
+            (
+                'After you finish this phase, you will receive an updated personal wellbeing summary. '
+                'We hope you will continue with us.'
+            ),
+            'We will send your daily link once the phase begins.',
+        ],
+        'paragraphs_ur': [
+            'آپ کا اگلا مرحلہ چند دنوں میں شروع ہوگا، ایک اور سات روزہ تحریری مشق کے ساتھ۔',
+            'اس مرحلے کے اختتام پر آپ کو ایک تازہ ذاتی بہبود رپورٹ موصول ہوگی۔ ہمیں اُمید ہے کہ آپ ہمارے ساتھ جاری رکھیں گے۔',
+            'مرحلہ شروع ہوتے ہی ہم آپ کو روزانہ کا لنک بھیجیں گے۔',
+        ],
+    },
+    'phase_4': {
+        'subject_en': 'Your next phase starts soon',
+        'subject_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'title_en': 'Your Next Phase Starts Soon',
+        'title_ur': 'آپ کا اگلا مرحلہ جلد شروع ہو رہا ہے',
+        'paragraphs_en': [
+            'Your next phase begins in a few days, with another seven-day writing exercise.',
+            (
+                'After you finish, you will receive an updated personal wellbeing summary. '
+                'We are grateful you have stayed with the study this long.'
+            ),
+            'We will send your daily link once the phase begins.',
+        ],
+        'paragraphs_ur': [
+            'آپ کا اگلا مرحلہ چند دنوں میں شروع ہوگا، ایک اور سات روزہ تحریری مشق کے ساتھ۔',
+            'اس کے اختتام پر آپ کو ایک تازہ ذاتی بہبود رپورٹ موصول ہوگی۔ ہم شکر گزار ہیں کہ آپ اتنے عرصے سے ہمارے ساتھ ہیں۔',
+            'مرحلہ شروع ہوتے ہی ہم آپ کو روزانہ کا لنک بھیجیں گے۔',
+        ],
+    },
+    'final': {
+        'subject_en': 'Your final phase starts soon',
+        'subject_ur': 'آپ کا آخری مرحلہ جلد شروع ہو رہا ہے',
+        'title_en': 'Your Final Phase Starts Soon',
+        'title_ur': 'آپ کا آخری مرحلہ جلد شروع ہو رہا ہے',
+        'paragraphs_en': [
+            'Your final phase of the study begins in a few days, with one last seven-day writing exercise.',
+            (
+                'After you complete it, you will receive your final personal wellbeing summary and a '
+                'certificate of completion. Thank you for staying with the study all the way to this point.'
+            ),
+            'We will send your daily link once the phase begins.',
+        ],
+        'paragraphs_ur': [
+            'تحقیق کا آپ کا آخری مرحلہ چند دنوں میں شروع ہوگا، آخری سات روزہ تحریری مشق کے ساتھ۔',
+            (
+                'اسے مکمل کرنے کے بعد آپ کو اپنی آخری ذاتی بہبود رپورٹ اور تکمیل کا سرٹیفکیٹ موصول ہوگا۔ '
+                'آخر تک ہمارے ساتھ رہنے کا شکریہ۔'
+            ),
+            'مرحلہ شروع ہوتے ہی ہم آپ کو روزانہ کا لنک بھیجیں گے۔',
+        ],
+    },
+}
+
+PHASE_REPORT_COMPLETE_EMAIL = {
+    'phase_3_report': {
+        'subject_en': 'Phase complete : your updated wellbeing summary',
+        'subject_ur': 'مرحلہ مکمل : آپ کی تازہ بہبود رپورٹ',
+        'title_en': 'Phase Complete',
+        'title_ur': 'مرحلہ مکمل',
+        'paragraphs_en': [
+            'You have completed this phase. Thank you for your continued participation.',
+            (
+                'Your updated personal wellbeing summary (PERMA Profiler) is attached as a PDF. As before, '
+                'it is a snapshot for your own reflection, not a clinical or diagnostic assessment, and small '
+                'changes over time are normal and can be influenced by many factors.'
+            ),
+            'Please wait for our next message, when the following phase will begin.',
+        ],
+        'paragraphs_ur': [
+            'آپ نے یہ مرحلہ مکمل کر لیا ہے۔ آپ کی مسلسل شرکت کا شکریہ۔',
+            (
+                'آپ کی تازہ ذاتی بہبود رپورٹ (PERMA پروفائلر) بطور PDF منسلک ہے۔ پہلے کی طرح، '
+                'یہ صرف آپ کے غور و فکر کے لیے ایک جھلک ہے، کوئی طبی یا تشخیصی جائزہ نہیں، '
+                'اور وقت کے ساتھ معمولی تبدیلیاں فطری ہیں اور کئی عوامل سے متاثر ہو سکتی ہیں۔'
+            ),
+            'براہِ کرم ہمارے اگلے پیغام کا انتظار کیجیے، جب اگلا مرحلہ شروع ہوگا۔',
+        ],
+        'closing_en': 'Warm regards,',
+        'closing_team_en': 'Psycheversity Research Team',
+        'closing_ur': 'نیک تمناؤں کے ساتھ،',
+        'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+    },
+    'phase_4_report': {
+        'subject_en': 'Phase complete : your updated wellbeing summary',
+        'subject_ur': 'مرحلہ مکمل : آپ کی تازہ بہبود رپورٹ',
+        'title_en': 'Phase Complete',
+        'title_ur': 'مرحلہ مکمل',
+        'paragraphs_en': [
+            'You have completed this phase. Thank you for your continued participation.',
+            (
+                'Your updated personal wellbeing summary (PERMA Profiler) is attached as a PDF. As before, '
+                'it is a snapshot for your own reflection, not a clinical or diagnostic assessment, and changes '
+                'over time can be influenced by many factors.'
+            ),
+            'Please wait for our next message, when the final phase will begin.',
+        ],
+        'paragraphs_ur': [
+            'آپ نے یہ مرحلہ مکمل کر لیا ہے۔ آپ کی مسلسل شرکت کا شکریہ۔',
+            (
+                'آپ کی تازہ ذاتی بہبود رپورٹ (PERMA پروفائلر) بطور PDF منسلک ہے۔ پہلے کی طرح، '
+                'یہ صرف آپ کے غور و فکر کے لیے ایک جھلک ہے، کوئی طبی یا تشخیصی جائزہ نہیں، '
+                'اور وقت کے ساتھ تبدیلیاں کئی عوامل سے متاثر ہو سکتی ہیں۔'
+            ),
+            'براہِ کرم ہمارے اگلے پیغام کا انتظار کیجیے، جب آخری مرحلہ شروع ہوگا۔',
+        ],
+        'closing_en': 'Warm regards,',
+        'closing_team_en': 'Psycheversity Research Team',
+        'closing_ur': 'نیک تمناؤں کے ساتھ،',
+        'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+    },
+    'study_complete': {
+        'subject_en': 'Study complete : your summary and certificate',
+        'subject_ur': 'تحقیق مکمل : آپ کی رپورٹ اور سرٹیفکیٹ',
+        'title_en': 'Study Complete',
+        'title_ur': 'تحقیق مکمل',
+        'paragraphs_en': [
+            'Congratulations on completing the Psycheversity Wellbeing Study, including all booster writing exercises, over a twelve-month period.',
+            (
+                'Attached you will find your final personal wellbeing summary (PERMA Profiler) and your '
+                'certificate of completion.'
+            ),
+            (
+                'Thank you for your dedication and for helping advance wellbeing research. '
+                'We are deeply grateful for your participation.'
+            ),
+        ],
+        'paragraphs_ur': [
+            'سائیکیورسٹی wellbeing تحقیق مکمل کرنے پر مبارک ہو، بشمول تمام booster تحریری مشقیں، بارہ ماہ کے دوران۔',
+            'منسلک فائلوں میں آپ کی آخری ذاتی wellbeing رپورٹ (PERMA Profiler) اور تکمیل کا سرٹیفکیٹ شامل ہے۔',
+            'آپ کی لگن اور wellbeing تحقیق کو آگے بڑھانے میں مدد کرنے کا شکریہ۔ ہم آپ کی شرکت کے بہت ممنون ہیں۔',
+        ],
+        'closing_en': 'Warm regards,',
+        'closing_team_en': 'Psycheversity Research Team',
+        'closing_ur': 'نیک تمناؤں کے ساتھ،',
+        'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+    },
+}

--- a/backend/emails/booster_schedule.py
+++ b/backend/emails/booster_schedule.py
@@ -1,0 +1,85 @@
+"""Booster / writing-phase email schedule from Psycheversity participant email doc."""
+
+from dataclasses import dataclass
+
+from django.utils import timezone
+
+# Activity wave → study phase number used in E3 subject/body merge fields.
+WAVE_TO_PHASE_NUMBER = {
+    'PRE_T1': 1,
+    'PRE_T_1M': 2,
+    'PRE_T2': 3,
+    'PRE_T3': 4,
+    'PRE_T4': 5,
+}
+
+# Enrollment day offsets (Day 0 = onboarding completion date).
+PHASE_INVITE_ENROLLMENT_DAYS = {
+    2: 'phase_2',      # E5 — booster 1 invite (Day 23)
+    3: 'phase_3',      # E7 — booster 2 invite (Day 83)
+    4: 'phase_4',      # E9 — booster 3 invite (Day 173)
+    5: 'final',        # E11 — final phase invite (Day 358)
+}
+PHASE_INVITE_DAY_BY_PHASE = {
+    2: 23,
+    3: 83,
+    4: 173,
+    5: 358,
+}
+
+MILESTONE_PHASE_COMPLETE = {
+    '7_DAYS': 'phase_1_complete',    # E4
+    '1_MONTH': 'phase_2_complete',   # E6
+    '3_MONTHS': 'phase_3_report',    # E8 (with PDF)
+    '6_MONTHS': 'phase_4_report',    # E10 (with PDF)
+    '1_YEAR': 'study_complete',      # E12 (with PDF + certificate note)
+}
+
+
+@dataclass(frozen=True)
+class ActiveWritingDay:
+    wave: str
+    phase_number: int
+    day_in_phase: int
+
+
+def get_enrollment_day(user) -> int | None:
+    """Days elapsed since onboarding completion (Day 0 = onboarding date)."""
+    if not user.onboarding_completed_at:
+        return None
+    onboarding_date = timezone.localtime(user.onboarding_completed_at).date()
+    return (timezone.localdate() - onboarding_date).days
+
+
+def get_active_writing_day(user) -> ActiveWritingDay | None:
+    """Return current booster writing day from platform activity state."""
+    if getattr(user, 'is_disqualified', False):
+        return None
+    if not user.onboarding_completed_at:
+        return None
+
+    state = user.current_activity_state
+    if state is None:
+        return None
+
+    phase_number = WAVE_TO_PHASE_NUMBER.get(state.wave)
+    if phase_number is None:
+        return None
+
+    return ActiveWritingDay(
+        wave=state.wave,
+        phase_number=phase_number,
+        day_in_phase=state.day_in_block,
+    )
+
+
+def get_due_phase_invite(user) -> str | None:
+    """Return invite template key if today is the doc-scheduled invite day."""
+    enrollment_day = get_enrollment_day(user)
+    if enrollment_day is None:
+        return None
+
+    for phase_number, invite_key in PHASE_INVITE_ENROLLMENT_DAYS.items():
+        if enrollment_day == PHASE_INVITE_DAY_BY_PHASE[phase_number]:
+            return invite_key
+    return None

--- a/backend/emails/booster_tasks.py
+++ b/backend/emails/booster_tasks.py
@@ -1,0 +1,182 @@
+import logging
+
+from celery import shared_task
+from celery.exceptions import Retry
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.utils import timezone
+
+from .booster_schedule import (
+    get_active_writing_day,
+    get_due_phase_invite,
+)
+from .builder import (
+    build_daily_nudge_email,
+    build_phase_complete_email,
+    build_phase_invite_email,
+    get_first_name,
+)
+from .tasks import _send_participant_email
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def _booster_e3_cache_key(user_id: int, wave: str, day_in_phase: int) -> str:
+    today = timezone.localdate().isoformat()
+    return f'booster_e3_{user_id}_{wave}_{day_in_phase}_{today}'
+
+
+def _booster_invite_cache_key(user_id: int, invite_key: str) -> str:
+    return f'booster_invite_{user_id}_{invite_key}'
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_daily_nudge_email_task(self, user_id: int, *, wave: str, phase: int, day_in_phase: int):
+    """Send E3 bilingual daily writing nudge for an active booster day."""
+    cache_key = _booster_e3_cache_key(user_id, wave, day_in_phase)
+    if cache.get(cache_key):
+        return {'status': 'skipped', 'reason': 'already_sent_today'}
+
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return {'status': 'skipped', 'reason': 'user_not_found'}
+
+    if not user.email or user.is_disqualified or not user.is_active:
+        return {'status': 'skipped', 'reason': 'ineligible'}
+
+    first_name = get_first_name(user)
+    email_content = build_daily_nudge_email(
+        first_name,
+        phase=phase,
+        day_in_phase=day_in_phase,
+    )
+
+    try:
+        _send_participant_email(email_content, user.email)
+        cache.set(cache_key, True, timeout=86400)
+        logger.info(
+            'Sent daily nudge (phase %s day %s) to %s',
+            phase, day_in_phase, user.email,
+        )
+        return {'status': 'sent', 'recipient': user.email}
+    except Exception as exc:
+        logger.error('Error sending daily nudge to %s: %s', user.email, exc)
+        if isinstance(exc, Retry):
+            raise
+        raise self.retry(exc=exc) from exc
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_phase_invite_email_task(self, user_id: int, invite_key: str):
+    """Send E5/E7/E9/E11 bilingual phase invite before a booster window."""
+    cache_key = _booster_invite_cache_key(user_id, invite_key)
+    if cache.get(cache_key):
+        return {'status': 'skipped', 'reason': 'already_sent'}
+
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return {'status': 'skipped', 'reason': 'user_not_found'}
+
+    if not user.email or user.is_disqualified or not user.is_active:
+        return {'status': 'skipped', 'reason': 'ineligible'}
+
+    first_name = get_first_name(user)
+    email_content = build_phase_invite_email(first_name, invite_key)
+
+    try:
+        _send_participant_email(email_content, user.email)
+        cache.set(cache_key, True, timeout=86400 * 400)
+        logger.info('Sent phase invite (%s) to %s', invite_key, user.email)
+        return {'status': 'sent', 'recipient': user.email}
+    except Exception as exc:
+        logger.error('Error sending phase invite to %s: %s', user.email, exc)
+        if isinstance(exc, Retry):
+            raise
+        raise self.retry(exc=exc) from exc
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_phase_complete_email_task(
+    self,
+    user_id: int,
+    template_key: str,
+    *,
+    attachments: list | None = None,
+):
+    """Send E4/E6/E8/E10/E12 bilingual phase-complete email."""
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return {'status': 'skipped', 'reason': 'user_not_found'}
+
+    if not user.email or user.is_disqualified:
+        return {'status': 'skipped', 'reason': 'ineligible'}
+
+    first_name = get_first_name(user)
+    email_content = build_phase_complete_email(first_name, template_key)
+    attachment_tuples = attachments or []
+
+    try:
+        _send_participant_email(email_content, user.email, attachments=attachment_tuples)
+        logger.info('Sent phase complete email (%s) to %s', template_key, user.email)
+        return {'status': 'sent', 'recipient': user.email}
+    except Exception as exc:
+        logger.error('Error sending phase complete email to %s: %s', user.email, exc)
+        if isinstance(exc, Retry):
+            raise
+        raise self.retry(exc=exc) from exc
+
+
+@shared_task
+def send_booster_daily_nudges():
+    """Celery Beat: send E3 to every participant in an active 7-day writing window."""
+    participants = User.objects.filter(
+        has_completed_sociodemographic=True,
+        is_active=True,
+        is_disqualified=False,
+        onboarding_completed_at__isnull=False,
+    )
+
+    sent = 0
+    for user in participants.iterator(chunk_size=500):
+        writing_day = get_active_writing_day(user)
+        if writing_day is None:
+            continue
+
+        result = send_daily_nudge_email_task(
+            user.user_id,
+            wave=writing_day.wave,
+            phase=writing_day.phase_number,
+            day_in_phase=writing_day.day_in_phase,
+        )
+        if isinstance(result, dict) and result.get('status') == 'sent':
+            sent += 1
+
+    return f'Sent {sent} booster daily nudges.'
+
+
+@shared_task
+def send_booster_phase_invites():
+    """Celery Beat: send phase invite emails on doc-scheduled enrollment days."""
+    participants = User.objects.filter(
+        has_completed_sociodemographic=True,
+        is_active=True,
+        is_disqualified=False,
+        onboarding_completed_at__isnull=False,
+    )
+
+    sent = 0
+    for user in participants.iterator(chunk_size=500):
+        invite_key = get_due_phase_invite(user)
+        if invite_key is None:
+            continue
+
+        result = send_phase_invite_email_task(user.user_id, invite_key)
+        if isinstance(result, dict) and result.get('status') == 'sent':
+            sent += 1
+
+    return f'Sent {sent} booster phase invites.'

--- a/backend/emails/builder.py
+++ b/backend/emails/builder.py
@@ -426,3 +426,113 @@ def build_screen_out_email(first_name: str, links: dict[str, str] | None = None)
         'text_content': text_content,
         'html_content': html_content,
     }
+
+
+def get_exercise_button_link() -> str:
+    base_url = settings.SITE_BASE_URL.rstrip('/')
+    return f'{base_url}/dashboard'
+
+
+def _build_cta_button_html(link: str, label_en: str, label_ur: str) -> tuple[str, str, str, str]:
+    en_html = (
+        f'<div style="margin: 24px 0; text-align: center;">'
+        f'<a href="{link}" style="background-color: {NAVY}; color: #ffffff; padding: 14px 28px; '
+        f'text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">'
+        f'{label_en}</a></div>'
+    )
+    ur_html = (
+        f'<div style="margin: 24px 0; text-align: center;">'
+        f'<a href="{link}" style="background-color: {NAVY}; color: #ffffff; padding: 14px 28px; '
+        f'text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">'
+        f'{label_ur}</a></div>'
+    )
+    return en_html, ur_html, f'{label_en}: {link}', f'{label_ur}: {link}'
+
+
+def build_daily_nudge_email(
+    first_name: str,
+    *,
+    phase: int,
+    day_in_phase: int,
+    exercise_link: str | None = None,
+    links: dict[str, str] | None = None,
+) -> dict[str, str]:
+    from .booster_content import DAILY_NUDGE_EMAIL
+
+    links = links or get_email_links()
+    exercise_link = exercise_link or get_exercise_button_link()
+    subject_en = DAILY_NUDGE_EMAIL['subject_en'].format(phase=phase, day_in_phase=day_in_phase)
+    subject_ur = DAILY_NUDGE_EMAIL['subject_ur'].format(phase=phase, day_in_phase=day_in_phase)
+
+    lead_en = DAILY_NUDGE_EMAIL['lead_en'].format(
+        first_name=first_name, phase=phase, day_in_phase=day_in_phase,
+    )
+    lead_ur = DAILY_NUDGE_EMAIL['lead_ur'].format(
+        first_name=first_name, phase=phase, day_in_phase=day_in_phase,
+    )
+    cta_en, cta_ur, cta_en_text, cta_ur_text = _build_cta_button_html(
+        exercise_link,
+        DAILY_NUDGE_EMAIL['button_en'],
+        DAILY_NUDGE_EMAIL['button_ur'],
+    )
+
+    email_shell = {
+        'subject_en': subject_en,
+        'subject_ur': subject_ur,
+        'title_en': DAILY_NUDGE_EMAIL['title_en'],
+        'title_ur': DAILY_NUDGE_EMAIL['title_ur'],
+        'paragraphs_en': [lead_en.replace(f'Dear {first_name}, ', '')],
+        'paragraphs_ur': [lead_ur.replace(f'محترم {first_name}، ', '')],
+        'closing_en': '',
+        'closing_team_en': 'Psycheversity Research Team',
+        'closing_ur': '',
+        'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+    }
+    result = _build_simple_bilingual_email(
+        first_name,
+        email_shell,
+        links=links,
+        extra_english_html=cta_en,
+        extra_urdu_html=cta_ur,
+        extra_english_text=cta_en_text,
+        extra_urdu_text=cta_ur_text,
+    )
+    result['subject'] = build_bilingual_subject(subject_en, subject_ur)
+    return result
+
+
+def build_phase_invite_email(
+    first_name: str,
+    invite_key: str,
+    links: dict[str, str] | None = None,
+) -> dict[str, str]:
+    from .booster_content import PHASE_INVITE_TEMPLATES
+
+    template = PHASE_INVITE_TEMPLATES[invite_key]
+    shell = {
+        **template,
+        'closing_en': 'Warm regards,',
+        'closing_team_en': 'Psycheversity Research Team',
+        'closing_ur': 'نیک تمناؤں کے ساتھ،',
+        'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+    }
+    return _build_simple_bilingual_email(first_name, shell, links=links)
+
+
+def build_phase_complete_email(
+    first_name: str,
+    template_key: str,
+    links: dict[str, str] | None = None,
+) -> dict[str, str]:
+    from .booster_content import (
+        PHASE_1_COMPLETE_EMAIL,
+        PHASE_2_COMPLETE_EMAIL,
+        PHASE_REPORT_COMPLETE_EMAIL,
+    )
+
+    templates = {
+        'phase_1_complete': PHASE_1_COMPLETE_EMAIL,
+        'phase_2_complete': PHASE_2_COMPLETE_EMAIL,
+        **PHASE_REPORT_COMPLETE_EMAIL,
+    }
+    return _build_simple_bilingual_email(first_name, templates[template_key], links=links)

--- a/backend/emails/tasks.py
+++ b/backend/emails/tasks.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def _send_participant_email(email_content: dict[str, str], recipient: str) -> None:
+def _send_participant_email(
+    email_content: dict[str, str],
+    recipient: str,
+    *,
+    attachments: list[tuple[str, bytes, str]] | None = None,
+) -> None:
     from django.core.mail import EmailMultiAlternatives
 
     msg = EmailMultiAlternatives(
@@ -27,6 +32,8 @@ def _send_participant_email(email_content: dict[str, str], recipient: str) -> No
         reply_to=[settings.PARTICIPANT_EMAIL_REPLY_TO],
     )
     msg.attach_alternative(email_content['html_content'], 'text/html')
+    for filename, content, mimetype in attachments or []:
+        msg.attach(filename, content, mimetype)
     msg.send(fail_silently=False)
 
 

--- a/backend/emails/tests/test_booster_emails.py
+++ b/backend/emails/tests/test_booster_emails.py
@@ -1,0 +1,144 @@
+import pytest
+from django.core import mail
+from django.utils import timezone
+from freezegun import freeze_time
+
+from emails.booster_schedule import (
+    get_active_writing_day,
+    get_due_phase_invite,
+    get_enrollment_day,
+)
+from emails.booster_tasks import (
+    send_booster_daily_nudges,
+    send_booster_phase_invites,
+    send_daily_nudge_email_task,
+    send_phase_complete_email_task,
+    send_phase_invite_email_task,
+)
+from emails.builder import build_daily_nudge_email, build_phase_invite_email
+
+
+def test_build_daily_nudge_email_is_bilingual():
+    content = build_daily_nudge_email('Sara', phase=1, day_in_phase=3)
+
+    assert 'Day 3 of Phase 1' in content['subject']
+    assert 'مرحلہ 1 کا دن 3' in content['subject']
+    assert 'Start today\'s exercise' in content['html_content']
+    assert 'آج کی مشق شروع کریں' in content['html_content']
+    assert '/dashboard' in content['html_content']
+
+
+def test_build_phase_invite_email_phase_3():
+    content = build_phase_invite_email('Sara', 'phase_3')
+    assert 'Your next phase starts soon' in content['subject']
+    assert 'updated personal wellbeing summary' in content['html_content']
+
+
+@pytest.mark.django_db
+def test_enrollment_day_and_invite_schedule(test_user):
+    onboarding = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
+    test_user.onboarding_completed_at = onboarding
+    test_user.has_completed_sociodemographic = True
+    test_user.save()
+
+    with freeze_time(onboarding):
+        assert get_enrollment_day(test_user) == 0
+
+    day_23 = onboarding + timezone.timedelta(days=23)
+    with freeze_time(day_23):
+        assert get_enrollment_day(test_user) == 23
+        assert get_due_phase_invite(test_user) == 'phase_2'
+
+
+@pytest.mark.django_db
+def test_send_daily_nudge_email_task(test_user):
+    test_user.full_name = 'Sara Ahmed'
+    test_user.has_completed_sociodemographic = True
+    test_user.onboarding_completed_at = timezone.now()
+    test_user.save()
+
+    result = send_daily_nudge_email_task(
+        test_user.user_id,
+        wave='PRE_T1',
+        phase=1,
+        day_in_phase=2,
+    )
+
+    assert result['status'] == 'sent'
+    assert len(mail.outbox) == 1
+    assert 'Day 2 of Phase 1' in mail.outbox[0].subject
+
+    result_again = send_daily_nudge_email_task(
+        test_user.user_id,
+        wave='PRE_T1',
+        phase=1,
+        day_in_phase=2,
+    )
+    assert result_again['status'] == 'skipped'
+    assert result_again['reason'] == 'already_sent_today'
+
+
+@pytest.mark.django_db
+def test_send_phase_invite_email_task(test_user):
+    test_user.full_name = 'Sara Ahmed'
+    test_user.save()
+
+    result = send_phase_invite_email_task(test_user.user_id, 'phase_2')
+    assert result['status'] == 'sent'
+    assert 'Your next phase starts soon' in mail.outbox[0].subject
+
+    result_again = send_phase_invite_email_task(test_user.user_id, 'phase_2')
+    assert result_again['status'] == 'skipped'
+
+
+@pytest.mark.django_db
+def test_send_phase_complete_email_task(test_user):
+    test_user.full_name = 'Sara Ahmed'
+    test_user.save()
+
+    result = send_phase_complete_email_task(test_user.user_id, 'phase_1_complete')
+    assert result['status'] == 'sent'
+    assert 'Phase 1 complete' in mail.outbox[0].subject
+
+
+@pytest.mark.django_db
+def test_send_booster_daily_nudges_batch(test_user, test_group):
+    test_group.is_active = True
+    test_group.save()
+    test_user.group = test_group
+    test_user.has_completed_sociodemographic = True
+    test_user.onboarding_completed_at = timezone.now()
+    test_user.save()
+
+    result = send_booster_daily_nudges()
+    assert 'Sent 1 booster daily nudges' in result
+    assert len(mail.outbox) == 1
+
+
+@pytest.mark.django_db
+def test_send_booster_phase_invites_batch(test_user):
+    onboarding = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
+    test_user.has_completed_sociodemographic = True
+    test_user.onboarding_completed_at = onboarding
+    test_user.save()
+
+    day_83 = onboarding + timezone.timedelta(days=83)
+    with freeze_time(day_83):
+        result = send_booster_phase_invites()
+        assert 'Sent 1 booster phase invites' in result
+        assert 'Your next phase starts soon' in mail.outbox[0].subject
+
+
+@pytest.mark.django_db
+def test_get_active_writing_day_uses_platform_state(test_user, test_group):
+    test_group.is_active = True
+    test_group.save()
+    test_user.group = test_group
+    test_user.has_completed_sociodemographic = True
+    test_user.onboarding_completed_at = timezone.now()
+    test_user.save()
+
+    writing_day = get_active_writing_day(test_user)
+    assert writing_day is not None
+    assert writing_day.phase_number == 1
+    assert 1 <= writing_day.day_in_phase <= 7

--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -132,15 +132,14 @@ def check_and_send_daily_reminders(reminder_type='morning'):
                 if reminder_type == 'evening':
                     msg = "Good evening! You haven't completed your daily reflection yet. There's still time!"
             
-            # Create a notification record
+            # Create a whatsapp notification only — bilingual E3 email is sent by emails.booster_tasks.
             n = Notification.objects.create(
                 user=user,
-                n_type='email', # Default to email as requested
+                n_type='whatsapp',
                 message=msg,
                 scheduled_time=timezone.now(),
                 status='pending'
             )
-            # Trigger the individual sending task
             send_notification.delay(n.id)
             reminded_count += 1
             

--- a/backend/notifications/tests/test_reminders.py
+++ b/backend/notifications/tests/test_reminders.py
@@ -48,14 +48,14 @@ class TestDailyReminders:
         # Mark User 2 as having submitted today
         Submission.objects.create(user=u2, activity=today_activity, content="Done")
         
-        # Run morning reminder
+        # Run morning reminder (whatsapp only — E3 email handled by emails.booster_tasks)
         result = check_and_send_daily_reminders(reminder_type='morning')
         
         # Assertions
         assert "Sent 1 morning reminders" in result
         
-        # Verify User 1 got a notification, but User 2 and 3 did not
-        assert Notification.objects.filter(user=u1, message__icontains="morning").exists()
+        # Verify User 1 got a whatsapp notification, but User 2 and 3 did not
+        assert Notification.objects.filter(user=u1, n_type='whatsapp', message__icontains="morning").exists()
         assert not Notification.objects.filter(user=u2).exists()
         assert not Notification.objects.filter(user=u3).exists()
         
@@ -71,8 +71,9 @@ class TestDailyReminders:
         
         assert "Sent 2 evening reminders" in result # User 1 and User 2 both haven't submitted
         
-        # Verify evening specific message
+        # Verify evening specific message (whatsapp)
         notification = Notification.objects.filter(user=u1).first()
+        assert notification.n_type == 'whatsapp'
         assert "Good evening" in notification.message
         assert "still time" in notification.message
 

--- a/backend/questionnaires/serializers.py
+++ b/backend/questionnaires/serializers.py
@@ -368,6 +368,20 @@ class ResponseSetSubmitSerializer(serializers.ModelSerializer):
                     lambda user_id=user.user_id: send_welcome_email_task.delay(user_id)
                 )
 
+            if (
+                instance.questionnaire.assessment_type == 'PSYCHOMETRIC'
+                and instance.milestone in ('7_DAYS', '1_MONTH', '6_MONTHS', '1_YEAR')
+            ):
+                from emails.booster_schedule import MILESTONE_PHASE_COMPLETE
+                from emails.booster_tasks import send_phase_complete_email_task
+
+                template_key = MILESTONE_PHASE_COMPLETE[instance.milestone]
+                transaction.on_commit(
+                    lambda user_id=user.user_id, key=template_key: send_phase_complete_email_task.delay(
+                        user_id, key
+                    )
+                )
+
             # Trigger Month-3 PERMA report task if 3_MONTHS milestone of PSYCHOMETRIC questionnaire is completed
             if instance.milestone == '3_MONTHS' and instance.questionnaire.assessment_type == 'PSYCHOMETRIC':
                 from questionnaires.tasks import send_month_3_report_task

--- a/backend/questionnaires/tasks.py
+++ b/backend/questionnaires/tasks.py
@@ -29,7 +29,6 @@ def send_month_3_report_task(response_set_id):
     Generate and email the Month-3 PERMA trajectory report PDF to the participant.
     """
     from questionnaires.models import ResponseSet
-    from django.core.mail import EmailMultiAlternatives
     from django.conf import settings
     from django.template.loader import render_to_string
     from django.utils import timezone
@@ -171,51 +170,17 @@ def send_month_3_report_task(response_set_id):
         # 4. Generate PDF via WeasyPrint
         pdf_bytes = HTML(string=html_string).write_pdf()
 
-        # 5. Email PDF Attachment
-        subject = "Three Months PERMA Profiler Report / تین ماہ کی PERMA پروفائلر رپورٹ"
-        text_content = (
-            f"Dear Participant,\n\n"
-            f"Please find attached your Month-3 PERMA feedback report. Please continue to your next entries.\n\n"
-            f"Sincerely,\n"
-            f"PIMS Team\n\n"
-            f"--------------------------------------------------\n\n"
-            f"محترم شریک کار،\n\n"
-            f"براہ کرم منسلک فائل میں اپنے تیسرے مہینے کی PERMA فیڈبیک رپورٹ حاصل کریں۔ براہ کرم اپنے اگلے اندراجات جاری رکھیں۔\n\n"
-            f"شکریہ،\n"
-            f"PIMS ٹیم"
+        # 5. Email PDF Attachment using doc-style E8 bilingual template
+        from emails.builder import build_phase_complete_email, get_first_name
+        from emails.tasks import _send_participant_email
+
+        first_name = get_first_name(user)
+        email_content = build_phase_complete_email(first_name, 'phase_3_report')
+        _send_participant_email(
+            email_content,
+            user.email,
+            attachments=[('pims_month3_report.pdf', pdf_bytes, 'application/pdf')],
         )
-        
-        html_body = f"""
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e4e4e7; border-radius: 8px;">
-            <h2 style="color: #2E4E90; margin-top: 0;">PIMS Feedback Report</h2>
-            <p style="font-size: 15px; color: #18181b;">Dear Participant,</p>
-            <p style="color: #3f3f46; font-size: 15px; line-height: 1.5;">
-                Please find attached your Month-3 PERMA feedback report in PDF format. Please continue to your next entries.
-            </p>
-            <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
-            <div style="direction: rtl; text-align: right; font-family: Arial, sans-serif;">
-                <p style="font-size: 16px; color: #2E4E90; margin-top: 0;">پی آئی ایم ایس فیڈبیک رپورٹ</p>
-                <p style="font-size: 15px; color: #18181b;">محترم شریک کار،</p>
-                <p style="color: #3f3f46; font-size: 15px; line-height: 1.5;">
-                    براہ کرم منسلک فائل میں اپنے تیسرے مہینے کی PERMA فیڈبیک رپورٹ حاصل کریں۔ براہ کرم اپنے اگلے اندراجات جاری رکھیں۔
-                </p>
-            </div>
-            <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
-            <p style="color: #71717a; font-size: 12px; margin-bottom: 0;">
-                This is an automated message from the Pakistan Intervention Management System. Please do not reply directly to this email.
-            </p>
-        </div>
-        """
-        
-        msg = EmailMultiAlternatives(
-            subject=subject,
-            body=text_content,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[user.email]
-        )
-        msg.attach_alternative(html_body, "text/html")
-        msg.attach("pims_month3_report.pdf", pdf_bytes, "application/pdf")
-        msg.send(fail_silently=False)
         
         logger.info("Successfully sent Month-3 report email to user %s (%s)", user.username, user.email)
         return {"status": "sent", "recipient": user.email}

--- a/backend/questionnaires/tests/test_month3_report.py
+++ b/backend/questionnaires/tests/test_month3_report.py
@@ -99,9 +99,12 @@ class TestMonth3Report:
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
         assert email.to == ['participant@test.com']
-        assert "Three Months PERMA Profiler Report" in email.subject
-        assert "Please continue to your next entries" in email.body
-        assert "براہ کرم اپنے اگلے اندراجات جاری رکھیں" in email.body
+        assert "Phase complete" in email.subject
+        assert "wellbeing summary" in email.subject
+        assert "You have completed this phase" in email.body
+        assert "PERMA Profiler" in email.body
+        assert "following phase will begin" in email.body
+        assert "آپ نے یہ مرحلہ مکمل کر لیا ہے" in email.body
 
         # 4. Assert PDF attachment is present
         assert len(email.attachments) == 1


### PR DESCRIPTION
Daily E3 nudges and phase invites run on Celery Beat; phase-complete emails fire on milestone submission; 3-month report uses E8 template.
Co-authored-by: khuzaimx <huzaimthegenius1234@gmail.com>