### PR TITLE
make signup verification and password reset emails bilingual

### DIFF
--- a/backend/emails/builder.py
+++ b/backend/emails/builder.py
@@ -536,3 +536,52 @@ def build_phase_complete_email(
         **PHASE_REPORT_COMPLETE_EMAIL,
     }
     return _build_simple_bilingual_email(first_name, templates[template_key], links=links)
+
+
+def build_otp_email(otp: str, links: dict[str, str] | None = None) -> dict[str, str]:
+    from .content import OTP_EMAIL
+
+    otp_html = (
+        f'<div style="margin: 24px 0; text-align: center;">'
+        f'<span style="background-color: #f8fafc; color: {NAVY}; font-size: 32px; '
+        f'font-weight: bold; letter-spacing: 4px; padding: 12px 30px; '
+        f'border: 2px solid #e2e8f0; border-radius: 8px; display: inline-block;'
+        f'font-family: Arial, sans-serif;">{otp}</span>'
+        f'</div>'
+    )
+    otp_text = f'\nVerification Code: {otp}\n'
+
+    return _build_simple_bilingual_email(
+        first_name="",
+        email_content=OTP_EMAIL,
+        links=links,
+        extra_english_html=otp_html,
+        extra_urdu_html=otp_html,
+        extra_english_text=otp_text,
+        extra_urdu_text=otp_text,
+    )
+
+
+def build_password_reset_email(first_name: str, otp: str, links: dict[str, str] | None = None) -> dict[str, str]:
+    from .content import PASSWORD_RESET_EMAIL
+
+    otp_html = (
+        f'<div style="margin: 24px 0; text-align: center;">'
+        f'<span style="background-color: #f8fafc; color: {NAVY}; font-size: 32px; '
+        f'font-weight: bold; letter-spacing: 4px; padding: 12px 30px; '
+        f'border: 2px solid #e2e8f0; border-radius: 8px; display: inline-block;'
+        f'font-family: Arial, sans-serif;">{otp}</span>'
+        f'</div>'
+    )
+    otp_text = f'\nVerification Code: {otp}\n'
+
+    return _build_simple_bilingual_email(
+        first_name=first_name,
+        email_content=PASSWORD_RESET_EMAIL,
+        links=links,
+        extra_english_html=otp_html,
+        extra_urdu_html=otp_html,
+        extra_english_text=otp_text,
+        extra_urdu_text=otp_text,
+    )
+

--- a/backend/emails/content.py
+++ b/backend/emails/content.py
@@ -220,3 +220,44 @@ STANDARD_FOOTER = {
         ),
     ],
 }
+
+
+OTP_EMAIL = {
+    'subject_en': 'Your Email Verification Code',
+    'subject_ur': 'آپ کا ای میل تصدیقی کوڈ',
+    'title_en': 'Email Verification',
+    'title_ur': 'ای میل کی تصدیق',
+    'paragraphs_en': [
+        'Welcome to Psycheversity! Your email verification code is below.',
+        'This code will expire in 10 minutes. Please enter this code on the registration page to complete your email verification.'
+    ],
+    'paragraphs_ur': [
+        'سائیکیورسٹی میں خوش آمدید! آپ کا ای میل تصدیقی کوڈ نیچے دیا گیا ہے۔',
+        'یہ کوڈ 10 منٹ میں ختم ہو جائے گا۔ ای میل کی تصدیق مکمل کرنے کے لیے براہِ کرم یہ کوڈ رجسٹریشن پیج پر درج کریں۔'
+    ],
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+
+
+PASSWORD_RESET_EMAIL = {
+    'subject_en': 'PIMS Password Reset Request',
+    'subject_ur': 'پاس ورڈ دوبارہ ترتیب دینے کی درخواست',
+    'title_en': 'Password Reset Verification',
+    'title_ur': 'پاس ورڈ دوبارہ ترتیب دینے کی تصدیق',
+    'paragraphs_en': [
+        'We received a request to reset your password. Use the verification code below to proceed.',
+        'This code will expire in 10 minutes. For security, please do not share this code with anyone. If you did not request this, you can safely ignore this email.'
+    ],
+    'paragraphs_ur': [
+        'ہمیں آپ کا پاس ورڈ دوبارہ ترتیب دینے کی درخواست موصول ہوئی ہے۔ آگے بڑھنے کے لیے نیچے دیا گیا تصدیقی کوڈ استعمال کریں۔',
+        'یہ کوڈ 10 منٹ میں ختم ہو جائے گا۔ سیکیورٹی وجوہات کی بناء پر، براہِ کرم یہ کوڈ کسی کے ساتھ شیئر نہ کریں۔ اگر آپ نے اس کی درخواست نہیں کی تھی، تو آپ اس ای میل کو نظر انداز کر سکتے ہیں۔'
+    ],
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+

--- a/backend/emails/tests/test_otp_password_reset_emails.py
+++ b/backend/emails/tests/test_otp_password_reset_emails.py
@@ -1,0 +1,91 @@
+import pytest
+from django.core import mail
+
+from emails.builder import build_otp_email, build_password_reset_email
+from users.tasks import send_otp_email_task, send_password_reset_email_task
+
+
+def test_build_otp_email_is_bilingual():
+    content = build_otp_email('123456')
+
+    # Subject checks
+    assert 'Your Email Verification Code' in content['subject']
+    assert 'آپ کا ای میل تصدیقی کوڈ' in content['subject']
+
+    # HTML body checks
+    assert '123456' in content['html_content']
+    assert 'Email Verification' in content['html_content']
+    assert 'ای میل کی تصدیق' in content['html_content']
+    assert 'Welcome to Psycheversity' in content['html_content']
+    assert 'سائیکیورسٹی میں خوش آمدید' in content['html_content']
+    assert 'Noto Nastaliq Urdu' in content['html_content']
+    assert 'dir="rtl"' in content['html_content']
+
+    # Text body checks
+    assert '123456' in content['text_content']
+    assert 'Your Email Verification Code' in content['text_content']
+    assert 'آپ کا ای میل تصدیقی کوڈ' in content['text_content']
+
+
+def test_build_password_reset_email_is_bilingual():
+    content = build_password_reset_email('Sara', '987654')
+
+    # Subject checks
+    assert 'PIMS Password Reset Request' in content['subject']
+    assert 'پاس ورڈ دوبارہ ترتیب دینے کی درخواست' in content['subject']
+
+    # HTML body checks
+    assert '987654' in content['html_content']
+    assert 'Dear Sara,' in content['html_content']
+    assert 'محترم Sara،' in content['html_content']
+    assert 'Password Reset Verification' in content['html_content']
+    assert 'پاس ورڈ دوبارہ ترتیب دینے کی تصدیق' in content['html_content']
+    assert 'Noto Nastaliq Urdu' in content['html_content']
+    assert 'dir="rtl"' in content['html_content']
+
+    # Text body checks
+    assert '987654' in content['text_content']
+    assert 'PIMS Password Reset Request' in content['text_content']
+    assert 'پاس ورڈ دوبارہ ترتیب دینے کی درخواست' in content['text_content']
+
+
+@pytest.mark.django_db
+def test_send_otp_email_task_sends_bilingual_email():
+    mail.outbox.clear()
+    
+    result = send_otp_email_task('otp_recipient@example.com', '123456')
+    assert result is True
+    assert len(mail.outbox) == 1
+    
+    message = mail.outbox[0]
+    assert message.to == ['otp_recipient@example.com']
+    assert 'Your Email Verification Code' in message.subject
+    assert 'آپ کا ای میل تصدیقی کوڈ' in message.subject
+    
+    # HTML alternative check
+    assert len(message.alternatives) == 1
+    html_body = message.alternatives[0][0]
+    assert '123456' in html_body
+    assert 'Welcome to Psycheversity' in html_body
+    assert 'سائیکیورسٹی میں خوش آمدید' in html_body
+
+
+@pytest.mark.django_db
+def test_send_password_reset_email_task_sends_bilingual_email():
+    mail.outbox.clear()
+    
+    result = send_password_reset_email_task('reset_recipient@example.com', 'Sara', '987654')
+    assert result is True
+    assert len(mail.outbox) == 1
+    
+    message = mail.outbox[0]
+    assert message.to == ['reset_recipient@example.com']
+    assert 'PIMS Password Reset Request' in message.subject
+    assert 'پاس ورڈ دوبارہ ترتیب دینے کی درخواست' in message.subject
+    
+    # HTML alternative check
+    assert len(message.alternatives) == 1
+    html_body = message.alternatives[0][0]
+    assert '987654' in html_body
+    assert 'Dear Sara,' in html_body
+    assert 'محترم Sara،' in html_body

--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -40,10 +40,22 @@ def send_notification(self, notification_id):
             
             msg_lower = notification.message.lower()
             if 'reflection' in msg_lower:
-                subject = "PIMS Daily Activity Reminder"
-                button_text = "Complete Today's Reflection"
-                title = "Daily Reflection Reminder"
-                dashboard_url = "https://psycheversity.com/dashboard"
+                from emails.builder import build_daily_nudge_email, get_first_name
+                from emails.booster_schedule import get_active_writing_day
+                from emails.tasks import _send_participant_email
+
+                first_name = get_first_name(user)
+                writing_day = get_active_writing_day(user)
+                if writing_day:
+                    phase = writing_day.phase_number
+                    day = writing_day.day_in_phase
+                else:
+                    phase = 1
+                    day = 1
+
+                email_content = build_daily_nudge_email(first_name, phase=phase, day_in_phase=day)
+                _send_participant_email(email_content, user.email)
+                logger.info("Successfully sent daily activity nudge email to %s", user.email)
             else:
                 if 'overdue' in msg_lower:
                     subject = "PIMS Assessment Overdue Reminder"
@@ -53,31 +65,31 @@ def send_notification(self, notification_id):
                     title = "Assessment Due Reminder"
                 button_text = "Go to Dashboard"
                 dashboard_url = "https://psycheversity.com/dashboard"
-                
-            text_content = f"Hi {name},\n\n{notification.message}\n\nPlease visit your dashboard: {dashboard_url}"
-            
-            html_content = f"""
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e4e4e7; border-radius: 8px;">
-                <h2 style="color: #18181b; margin-top: 0;">{title}</h2>
-                <p style="font-size: 16px; color: #18181b;">Hi {name},</p>
-                <p style="color: #3f3f46; font-size: 16px; line-height: 1.5;">{notification.message}</p>
-                <div style="margin: 25px 0;">
-                    <a href="{dashboard_url}" style="background-color: #18181b; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block;">{button_text}</a>
+
+                text_content = f"Hi {name},\n\n{notification.message}\n\nPlease visit your dashboard: {dashboard_url}"
+
+                html_content = f"""
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e4e4e7; border-radius: 8px;">
+                    <h2 style="color: #18181b; margin-top: 0;">{title}</h2>
+                    <p style="font-size: 16px; color: #18181b;">Hi {name},</p>
+                    <p style="color: #3f3f46; font-size: 16px; line-height: 1.5;">{notification.message}</p>
+                    <div style="margin: 25px 0;">
+                        <a href="{dashboard_url}" style="background-color: #18181b; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block;">{button_text}</a>
+                    </div>
+                    <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
+                    <p style="color: #71717a; font-size: 12px; margin-bottom: 0;">This is an automated message from the Psychological Intervention Platform. Please do not reply directly to this email.</p>
                 </div>
-                <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
-                <p style="color: #71717a; font-size: 12px; margin-bottom: 0;">This is an automated message from the Psychological Intervention Platform. Please do not reply directly to this email.</p>
-            </div>
-            """
-            
-            msg = EmailMultiAlternatives(
-                subject=subject,
-                body=text_content,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                to=[user.email]
-            )
-            msg.attach_alternative(html_content, "text/html")
-            msg.send(fail_silently=False)
-            logger.info("Successfully sent email notification to %s", user.email)
+                """
+
+                msg = EmailMultiAlternatives(
+                    subject=subject,
+                    body=text_content,
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    to=[user.email]
+                )
+                msg.attach_alternative(html_content, "text/html")
+                msg.send(fail_silently=False)
+                logger.info("Successfully sent email notification to %s", user.email)
             
         notification.status = 'sent'
         notification.save(update_fields=['status'])

--- a/backend/notifications/tests/test_tasks.py
+++ b/backend/notifications/tests/test_tasks.py
@@ -70,12 +70,12 @@ def test_send_daily_reflection_email_personalization(test_user):
     # Assert email was sent
     assert len(mail.outbox) == 1
     sent_email = mail.outbox[0]
-    assert sent_email.subject == "PIMS Daily Activity Reminder"
+    assert "Day 1 of Phase 1" in sent_email.subject
     assert sent_email.to == [test_user.email]
-    assert "Sarah Kim" in sent_email.body
-    assert "Sarah Kim" in sent_email.alternatives[0][0]
-    assert "complete your daily reflection today." in sent_email.body
-    assert "Complete Today's Reflection" in sent_email.alternatives[0][0]
+    assert "Sarah" in sent_email.body
+    assert "Sarah" in sent_email.alternatives[0][0]
+    assert "Start today's exercise" in sent_email.alternatives[0][0]
+    assert "آج کی مشق شروع کریں" in sent_email.alternatives[0][0]
 
     # 2. Notification without "reflection" in message (milestone/assessment due, should send due email)
     mail.outbox = []

--- a/backend/users/tasks.py
+++ b/backend/users/tasks.py
@@ -14,10 +14,12 @@ def send_otp_email_task(self, email, otp):
     """
     Sends the OTP email to the user using Django's configured email backend.
     """
+    from emails.builder import build_otp_email
 
-    subject = "Your Email Verification Code"
-    text_content = f"Hello, your verification code is {otp}."
-    html_content = f"<h3>Welcome!</h3><p>Your email verification code is: <strong>{otp}</strong></p><p>This code will expire in 10 minutes.</p>"
+    email_data = build_otp_email(otp)
+    subject = email_data['subject']
+    text_content = email_data['text_content']
+    html_content = email_data['html_content']
 
     msg = EmailMultiAlternatives(
         subject=subject,
@@ -52,22 +54,12 @@ def send_password_reset_email_task(self, email, name, otp):
     """
     Sends the password reset OTP email to the user.
     """
-    subject = "PIMS Password Reset Request"
-    text_content = f"Hello {name},\n\nWe received a request to reset your password. Your verification code is: {otp}.\n\nThis code will expire in 10 minutes. If you did not request this, please ignore this email."
-    
-    html_content = f"""
-    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e4e4e7; border-radius: 8px;">
-        <h2 style="color: #18181b; margin-top: 0;">Password Reset Verification</h2>
-        <p style="font-size: 16px; color: #18181b;">Hi {name},</p>
-        <p style="color: #3f3f46; font-size: 16px; line-height: 1.5;">We received a request to reset your password. Use the verification code below to proceed:</p>
-        <div style="margin: 25px 0; text-align: center;">
-            <span style="background-color: #f4f4f5; color: #18181b; font-size: 32px; font-weight: bold; letter-spacing: 4px; padding: 12px 30px; border: 2px solid #e4e4e7; border-radius: 6px; display: inline-block;">{otp}</span>
-        </div>
-        <p style="color: #ef4444; font-size: 14px;">This code will expire in 10 minutes. For security, please do not share this code with anyone.</p>
-        <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
-        <p style="color: #71717a; font-size: 12px; margin-bottom: 0;">If you did not request a password reset, you can safely ignore this email.</p>
-    </div>
-    """
+    from emails.builder import build_password_reset_email
+
+    email_data = build_password_reset_email(name, otp)
+    subject = email_data['subject']
+    text_content = email_data['text_content']
+    html_content = email_data['html_content']
 
     msg = EmailMultiAlternatives(
         subject=subject,
@@ -88,4 +80,5 @@ def send_password_reset_email_task(self, email, name, otp):
             raise e
         logger.warning(f"Retrying password reset email delivery to {email}...")
         raise self.retry(exc=e)
+
 


### PR DESCRIPTION
Makes the email verification code (OTP) sent during signup and the password reset verification code emails bilingual (English & Urdu) with premium styled templates.