### PR TITLE
feat: implement bilingual assessment reminders and fix email deliverability

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -323,7 +323,7 @@ DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='no-reply@psycheversity.c
 SITE_BASE_URL = env('SITE_BASE_URL', default='https://psycheversity.com')
 PARTICIPANT_EMAIL_FROM = env(
     'PARTICIPANT_EMAIL_FROM',
-    default='Psycheversity Research Team <support@psycheversity.com>',
+    default='Psycheversity Research Team <no-reply@psycheversity.com>',
 )
 PARTICIPANT_EMAIL_REPLY_TO = env('PARTICIPANT_EMAIL_REPLY_TO', default='support@psycheversity.com')
 PARTICIPANT_WITHDRAW_URL = env('PARTICIPANT_WITHDRAW_URL', default='')

--- a/backend/emails/booster_content.py
+++ b/backend/emails/booster_content.py
@@ -1,8 +1,8 @@
 """E3–E12 booster / phase email copy from Psycheversity_Participant_Emails_Bilingual.docx."""
 
 DAILY_NUDGE_EMAIL = {
-    'subject_en': "Day {day_in_phase} of Phase {phase} : today's writing exercise",
-    'subject_ur': 'مرحلہ {phase} کا دن {day_in_phase} : آج کی تحریری مشق',
+    'subject_en': "Daily Activity Reminder",
+    'subject_ur': 'روزانہ کی سرگرمی کی یاد دہانی',
     'title_en': "Today's Writing Exercise",
     'title_ur': 'آج کی تحریری مشق',
     'lead_en': (

--- a/backend/emails/booster_tasks.py
+++ b/backend/emails/booster_tasks.py
@@ -17,9 +17,8 @@ from .builder import (
     build_phase_invite_email,
     get_first_name,
 )
-from .tasks import _send_participant_email
-
 logger = logging.getLogger(__name__)
+
 User = get_user_model()
 
 
@@ -55,6 +54,7 @@ def send_daily_nudge_email_task(self, user_id: int, *, wave: str, phase: int, da
     )
 
     try:
+        from .tasks import _send_participant_email
         _send_participant_email(email_content, user.email)
         cache.set(cache_key, True, timeout=86400)
         logger.info(
@@ -88,6 +88,7 @@ def send_phase_invite_email_task(self, user_id: int, invite_key: str):
     email_content = build_phase_invite_email(first_name, invite_key)
 
     try:
+        from .tasks import _send_participant_email
         _send_participant_email(email_content, user.email)
         cache.set(cache_key, True, timeout=86400 * 400)
         logger.info('Sent phase invite (%s) to %s', invite_key, user.email)
@@ -121,6 +122,7 @@ def send_phase_complete_email_task(
     attachment_tuples = attachments or []
 
     try:
+        from .tasks import _send_participant_email
         _send_participant_email(email_content, user.email, attachments=attachment_tuples)
         logger.info('Sent phase complete email (%s) to %s', template_key, user.email)
         return {'status': 'sent', 'recipient': user.email}

--- a/backend/emails/builder.py
+++ b/backend/emails/builder.py
@@ -276,31 +276,35 @@ def _build_simple_bilingual_email(
     </html>
     """
 
-    text_content = '\n\n'.join([
+    text_content_blocks = [
         email_content['subject_en'],
         '',
-        f'Dear {first_name},',
-        *email_content['paragraphs_en'],
-        extra_english_text,
-        email_content['closing_en'],
-        email_content['closing_team_en'],
-        '',
-        email_content['subject_ur'],
-        '',
-        f'محترم {first_name}،',
-        *email_content['paragraphs_ur'],
-        extra_urdu_text,
-        email_content['closing_ur'],
-        email_content['closing_team_ur'],
-        '',
-        STANDARD_FOOTER['paragraphs_en'][0].format(**links),
-        STANDARD_FOOTER['paragraphs_en'][1].format(**links),
-        STANDARD_FOOTER['paragraphs_en'][2],
-        '',
-        STANDARD_FOOTER['paragraphs_ur'][0].format(**links),
-        STANDARD_FOOTER['paragraphs_ur'][1].format(**links),
-        STANDARD_FOOTER['paragraphs_ur'][2],
-    ])
+    ]
+    if first_name:
+        text_content_blocks.append(f'Dear {first_name},')
+    text_content_blocks.extend(email_content['paragraphs_en'])
+    text_content_blocks.append(extra_english_text)
+    text_content_blocks.append(email_content['closing_en'])
+    text_content_blocks.append(email_content['closing_team_en'])
+    text_content_blocks.append('')
+    text_content_blocks.append(email_content['subject_ur'])
+    text_content_blocks.append('')
+    if first_name:
+        text_content_blocks.append(f'محترم {first_name}،')
+    text_content_blocks.extend(email_content['paragraphs_ur'])
+    text_content_blocks.append(extra_urdu_text)
+    text_content_blocks.append(email_content['closing_ur'])
+    text_content_blocks.append(email_content['closing_team_ur'])
+    text_content_blocks.append('')
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_en'][0].format(**links))
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_en'][1].format(**links))
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_en'][2])
+    text_content_blocks.append('')
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_ur'][0].format(**links))
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_ur'][1].format(**links))
+    text_content_blocks.append(STANDARD_FOOTER['paragraphs_ur'][2])
+    
+    text_content = '\n\n'.join(text_content_blocks)
 
     return {
         'subject': subject,
@@ -489,7 +493,7 @@ def build_daily_nudge_email(
         'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
     }
     result = _build_simple_bilingual_email(
-        first_name,
+        "",  # Empty string so no greeting is rendered in HTML or text
         email_shell,
         links=links,
         extra_english_html=cta_en,
@@ -688,5 +692,92 @@ def build_consecutive_misses_email(
     )
     result['subject'] = build_bilingual_subject(subject_en, subject_ur)
     return result
+
+
+def build_assessment_due_email(message_en: str, links: dict[str, str] | None = None) -> dict[str, str]:
+    from .content import ASSESSMENT_DUE_EMAIL, ASSESSMENT_OVERDUE_EMAIL
+
+    # Normalize message for matching
+    msg_norm = message_en.strip()
+
+    # Determine if overdue or due
+    is_overdue = 'overdue' in msg_norm.lower()
+    email_content = ASSESSMENT_OVERDUE_EMAIL if is_overdue else ASSESSMENT_DUE_EMAIL
+
+    # Paragraph mapping
+    # Maps exact English message to Urdu message
+    mapping = {
+        # Standard Due
+        "Hello! Your 7-day post-test assessment is now due. Please complete it today!":
+            "السلام علیکم! آپ کا 7 روزہ پوسٹ ٹیسٹ اسیسمنٹ اب دستیاب ہے۔ براہِ کرم اسے آج ہی مکمل کریں۔",
+        "Hello! Your 1-month follow-up assessment is now due. Please complete it today!":
+            "السلام علیکم! آپ کا 1 ماہ کا فالو اپ اسیسمنٹ اب دستیاب ہے۔ براہِ کرم اسے آج ہی مکمل کریں۔",
+        "Hello! Your 3-month follow-up assessment is now due. Please complete it today!":
+            "السلام علیکم! آپ کا 3 ماہ کا فالو اپ اسیسمنٹ اب دستیاب ہے۔ براہِ کرم اسے آج ہی مکمل کریں۔",
+        "Hello! Your 6-month follow-up assessment is now due. Please complete it today!":
+            "السلام علیکم! آپ کا 6 ماہ کا فالو اپ اسیسمنٹ اب دستیاب ہے۔ براہِ کرم اسے آج ہی مکمل کریں۔",
+        "Hello! Your 1-year follow-up assessment is now due. Please complete it today!":
+            "السلام علیکم! آپ کا 1 سال کا فالو اپ اسیسمنٹ اب دستیاب ہے۔ براہِ کرم اسے آج ہی مکمل کریں۔",
+
+        # Final Re-engagement
+        "PIMS Final Re-engagement: We noticed you missed your previous follow-ups. This is our final attempt to re-engage you for the 7-day post-test assessment. Please complete it to stay active in the study.":
+            "پی آئی ایم ایس فائنل دوبارہ شمولیت: ہم نے دیکھا کہ آپ پچھلے فالو اپس مکمل نہیں کر پائے۔ یہ آپ کو 7 روزہ پوسٹ ٹیسٹ اسیسمنٹ کے لیے شامل کرنے کی ہماری آخری کوشش ہے۔ مطالعہ میں فعال رہنے کے لیے براہِ کرم اسے مکمل کریں۔",
+        "PIMS Final Re-engagement: We noticed you missed your previous follow-ups. This is our final attempt to re-engage you for the 1-month follow-up assessment. Please complete it to stay active in the study.":
+            "پی آئی ایم ایس فائنل دوبارہ شمولیت: ہم نے دیکھا کہ آپ پچھلے فالو اپس مکمل نہیں کر پائے۔ یہ آپ کو 1 ماہ کے فالو اپ اسیسمنٹ کے لیے شامل کرنے کی ہماری آخری کوشش ہے۔ مطالعہ میں فعال رہنے کے لیے براہِ کرم اسے مکمل کریں۔",
+        "PIMS Final Re-engagement: We noticed you missed your previous follow-ups. This is our final attempt to re-engage you for the 3-month follow-up assessment. Please complete it to stay active in the study.":
+            "پی آئی ایم ایس فائنل دوبارہ شمولیت: ہم نے دیکھا کہ آپ پچھلے فالو اپس مکمل نہیں کر پائے۔ یہ آپ کو 3 ماہ کے فالو اپ اسیسمنٹ کے لیے شامل کرنے کی ہماری آخری کوشش ہے۔ مطالعہ میں فعال رہنے کے لیے براہِ کرم اسے مکمل کریں۔",
+        "PIMS Final Re-engagement: We noticed you missed your previous follow-ups. This is our final attempt to re-engage you for the 6-month follow-up assessment. Please complete it to stay active in the study.":
+            "پی آئی ایم ایس فائنل دوبارہ شمولیت: ہم نے دیکھا کہ آپ پچھلے فالو اپس مکمل نہیں کر پائے۔ یہ آپ کو 6 ماہ کے فالو اپ اسیسمنٹ کے لیے شامل کرنے کی ہماری آخری کوشش ہے۔ مطالعہ میں فعال رہنے کے لیے براہِ کرم اسے مکمل کریں۔",
+        "PIMS Final Re-engagement: We noticed you missed your previous follow-ups. This is our final attempt to re-engage you for the 1-year follow-up assessment. Please complete it to stay active in the study.":
+            "پی آئی ایم ایس فائنل دوبارہ شمولیت: ہم نے دیکھا کہ آپ پچھلے فالو اپس مکمل نہیں کر پائے۔ یہ آپ کو 1 سال کے فالو اپ اسیسمنٹ کے لیے شامل کرنے کی ہماری آخری کوشش ہے۔ مطالعہ میں فعال رہنے کے لیے براہِ کرم اسے مکمل کریں۔",
+
+        # Overdue (1 Day Overdue)
+        "Reminder: Your 7-day post-test assessment is overdue. Please complete it at your earliest convenience.":
+            "یاد دہانی: آپ کا 7 روزہ پوسٹ ٹیسٹ اسیسمنٹ اب واجب الادہ ہے۔ براہِ کرم اسے اپنی اولین فرصت میں مکمل کریں۔",
+        "Reminder: Your 1-month follow-up assessment is overdue. Please complete it at your earliest convenience.":
+            "یاد دہانی: آپ کا 1 ماہ کا فالو اپ اسیسمنٹ اب واجب الادہ ہے۔ براہِ کرم اسے اپنی اولین فرصت میں مکمل کریں۔",
+        "Reminder: Your 3-month follow-up assessment is overdue. Please complete it at your earliest convenience.":
+            "یاد دہانی: آپ کا 3 ماہ کا فالو اپ اسیسمنٹ اب واجب الادہ ہے۔ براہِ کرم اسے اپنی اولین فرصت میں مکمل کریں۔",
+        "Reminder: Your 6-month follow-up assessment is overdue. Please complete it at your earliest convenience.":
+            "یاد دہانی: آپ کا 6 ماہ کا فالو اپ اسیسمنٹ اب واجب الادہ ہے۔ براہِ کرم اسے اپنی اولین فرصت میں مکمل کریں۔",
+        "Reminder: Your 1-year follow-up assessment is overdue. Please complete it at your earliest convenience.":
+            "یاد دہانی: آپ کا 1 سال کا فالو اپ اسیسمنٹ اب واجب الادہ ہے۔ براہِ کرم اسے اپنی اولین فرصت میں مکمل کریں۔",
+    }
+
+    message_ur = mapping.get(msg_norm, "براہِ کرم اپنی اسیسمنٹ مکمل کرنے کے لیے اپنے ڈیش بورڈ پر جائیں۔")
+
+    # Build the CTA button
+    dashboard_link = get_exercise_button_link()
+    cta_en_button, cta_ur_button, cta_en_text, cta_ur_text = _build_cta_button_html(
+        dashboard_link,
+        "Go to Dashboard",
+        "ڈیش بورڈ پر جائیں"
+    )
+
+    email_shell = {
+        'subject_en': email_content['subject_en'],
+        'subject_ur': email_content['subject_ur'],
+        'title_en': email_content['title_en'],
+        'title_ur': email_content['title_ur'],
+        'paragraphs_en': [message_en],
+        'paragraphs_ur': [message_ur],
+        'closing_en': email_content['closing_en'],
+        'closing_team_en': email_content['closing_team_en'],
+        'closing_ur': email_content['closing_ur'],
+        'closing_team_ur': email_content['closing_team_ur'],
+    }
+
+    # Use empty first name to prevent personal greeting in header ("Dear Name" / "Hi Name")
+    result = _build_simple_bilingual_email(
+        first_name="",
+        email_content=email_shell,
+        links=links,
+        extra_english_html=cta_en_button,
+        extra_urdu_html=cta_ur_button,
+        extra_english_text=cta_en_text,
+        extra_urdu_text=cta_ur_text,
+    )
+    return result
+
 
 

--- a/backend/emails/content.py
+++ b/backend/emails/content.py
@@ -261,3 +261,26 @@ PASSWORD_RESET_EMAIL = {
     'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
 }
 
+ASSESSMENT_DUE_EMAIL = {
+    'subject_en': 'Psycheversity Assessment Due Reminder',
+    'subject_ur': 'سائیکیورسٹی اسیسمنٹ کی یاد دہانی',
+    'title_en': 'Assessment Due Reminder',
+    'title_ur': 'اسیسمنٹ کی یاد دہانی',
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+
+ASSESSMENT_OVERDUE_EMAIL = {
+    'subject_en': 'Psycheversity Assessment Overdue Reminder',
+    'subject_ur': 'سائیکیورسٹی اسیسمنٹ کے وقت گزرنے کی یاد دہانی',
+    'title_en': 'Assessment Overdue Reminder',
+    'title_ur': 'اسیسمنٹ کے وقت گزرنے کی یاد دہانی',
+    'closing_en': 'Warm regards,',
+    'closing_team_en': 'Psycheversity Research Team',
+    'closing_ur': 'نیک تمناؤں کے ساتھ،',
+    'closing_team_ur': 'سائیکیورسٹی ریسرچ ٹیم',
+}
+
+

--- a/backend/emails/tasks.py
+++ b/backend/emails/tasks.py
@@ -148,3 +148,14 @@ def send_socio_disqualification_email_task(self, user_id: int):
         if isinstance(exc, Retry):
             raise
         raise self.retry(exc=exc) from exc
+
+
+# Ensure Celery autodiscovery registers these tasks
+from .booster_tasks import (
+    send_booster_daily_nudges,
+    send_booster_phase_invites,
+    send_daily_nudge_email_task,
+    send_phase_invite_email_task,
+    send_phase_complete_email_task,
+)
+

--- a/backend/emails/tests/test_booster_emails.py
+++ b/backend/emails/tests/test_booster_emails.py
@@ -21,8 +21,8 @@ from emails.builder import build_daily_nudge_email, build_phase_invite_email
 def test_build_daily_nudge_email_is_bilingual():
     content = build_daily_nudge_email('Sara', phase=1, day_in_phase=3)
 
-    assert 'Day 3 of Phase 1' in content['subject']
-    assert 'مرحلہ 1 کا دن 3' in content['subject']
+    assert 'Daily Activity Reminder' in content['subject']
+    assert 'روزانہ کی سرگرمی کی یاد دہانی' in content['subject']
     assert 'Start today\'s exercise' in content['html_content']
     assert 'آج کی مشق شروع کریں' in content['html_content']
     assert '/dashboard' in content['html_content']
@@ -66,7 +66,7 @@ def test_send_daily_nudge_email_task(test_user):
 
     assert result['status'] == 'sent'
     assert len(mail.outbox) == 1
-    assert 'Day 2 of Phase 1' in mail.outbox[0].subject
+    assert 'Daily Activity Reminder' in mail.outbox[0].subject
 
     result_again = send_daily_nudge_email_task(
         test_user.user_id,

--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -68,39 +68,13 @@ def send_notification(self, notification_id):
                 _send_participant_email(email_content, user.email)
                 logger.info("Successfully sent daily activity nudge email to %s", user.email)
             else:
-                if 'overdue' in msg_lower:
-                    subject = "PIMS Assessment Overdue Reminder"
-                    title = "Assessment Overdue Reminder"
-                else:
-                    subject = "PIMS Assessment Due Reminder"
-                    title = "Assessment Due Reminder"
-                button_text = "Go to Dashboard"
-                dashboard_url = "https://psycheversity.com/dashboard"
+                from emails.builder import build_assessment_due_email
+                from emails.tasks import _send_participant_email
 
-                text_content = f"Hi {name},\n\n{notification.message}\n\nPlease visit your dashboard: {dashboard_url}"
-
-                html_content = f"""
-                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e4e4e7; border-radius: 8px;">
-                    <h2 style="color: #18181b; margin-top: 0;">{title}</h2>
-                    <p style="font-size: 16px; color: #18181b;">Hi {name},</p>
-                    <p style="color: #3f3f46; font-size: 16px; line-height: 1.5;">{notification.message}</p>
-                    <div style="margin: 25px 0;">
-                        <a href="{dashboard_url}" style="background-color: #18181b; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block;">{button_text}</a>
-                    </div>
-                    <hr style="border: 0; border-top: 1px solid #e4e4e7; margin: 20px 0;">
-                    <p style="color: #71717a; font-size: 12px; margin-bottom: 0;">This is an automated message from the Psychological Intervention Platform. Please do not reply directly to this email.</p>
-                </div>
-                """
-
-                msg = EmailMultiAlternatives(
-                    subject=subject,
-                    body=text_content,
-                    from_email=settings.DEFAULT_FROM_EMAIL,
-                    to=[user.email]
-                )
-                msg.attach_alternative(html_content, "text/html")
-                msg.send(fail_silently=False)
-                logger.info("Successfully sent email notification to %s", user.email)
+                email_content = build_assessment_due_email(notification.message)
+                _send_participant_email(email_content, user.email)
+                logger.info("Successfully sent bilingual assessment due/overdue email notification to %s", user.email)
+            
             
         notification.status = 'sent'
         notification.save(update_fields=['status'])

--- a/backend/notifications/tests/test_tasks.py
+++ b/backend/notifications/tests/test_tasks.py
@@ -70,10 +70,10 @@ def test_send_daily_reflection_email_personalization(test_user):
     # Assert email was sent
     assert len(mail.outbox) == 1
     sent_email = mail.outbox[0]
-    assert "Day 1 of Phase 1" in sent_email.subject
+    assert "Daily Activity Reminder" in sent_email.subject
     assert sent_email.to == [test_user.email]
-    assert "Sarah" in sent_email.body
-    assert "Sarah" in sent_email.alternatives[0][0]
+    assert "Sarah" not in sent_email.body
+    assert "Sarah" not in sent_email.alternatives[0][0]
     assert "Start today's exercise" in sent_email.alternatives[0][0]
     assert "آج کی مشق شروع کریں" in sent_email.alternatives[0][0]
 
@@ -120,7 +120,7 @@ def test_send_daily_reflection_email_personalization(test_user):
     notif_due = Notification.objects.create(
         user=test_user,
         n_type='email',
-        message='Your 7-day post-test assessment is now due.',
+        message='Hello! Your 7-day post-test assessment is now due. Please complete it today!',
         scheduled_time=timezone.now(),
         status='pending'
     )
@@ -132,19 +132,22 @@ def test_send_daily_reflection_email_personalization(test_user):
     # Assert email was sent
     assert len(mail.outbox) == 1
     sent_email = mail.outbox[0]
-    assert sent_email.subject == "PIMS Assessment Due Reminder"
+    assert "Psycheversity Assessment Due Reminder" in sent_email.subject
+    assert "سائیکیورسٹی اسیسمنٹ کی یاد دہانی" in sent_email.subject
     assert sent_email.to == [test_user.email]
-    assert "Sarah Kim" in sent_email.body
+    assert "Sarah Kim" not in sent_email.body
     assert "Your 7-day post-test assessment is now due." in sent_email.body
     assert "Assessment Due Reminder" in sent_email.alternatives[0][0]
+    assert "اسیسمنٹ کی یاد دہانی" in sent_email.alternatives[0][0]
     assert "Go to Dashboard" in sent_email.alternatives[0][0]
+    assert "ڈیش بورڈ پر جائیں" in sent_email.alternatives[0][0]
 
     # 3. Notification without "reflection" in message (milestone/assessment overdue, should send overdue email)
     mail.outbox = []
     notif_overdue = Notification.objects.create(
         user=test_user,
         n_type='email',
-        message='Reminder: Your 3-month follow-up assessment is overdue.',
+        message='Reminder: Your 3-month follow-up assessment is overdue. Please complete it at your earliest convenience.',
         scheduled_time=timezone.now(),
         status='pending'
     )
@@ -156,12 +159,16 @@ def test_send_daily_reflection_email_personalization(test_user):
     # Assert email was sent
     assert len(mail.outbox) == 1
     sent_email_od = mail.outbox[0]
-    assert sent_email_od.subject == "PIMS Assessment Overdue Reminder"
+    assert "Psycheversity Assessment Overdue Reminder" in sent_email_od.subject
+    assert "سائیکیورسٹی اسیسمنٹ کے وقت گزرنے کی یاد دہانی" in sent_email_od.subject
     assert sent_email_od.to == [test_user.email]
-    assert "Sarah Kim" in sent_email_od.body
+    assert "Sarah Kim" not in sent_email_od.body
     assert "Reminder: Your 3-month follow-up assessment is overdue." in sent_email_od.body
     assert "Assessment Overdue Reminder" in sent_email_od.alternatives[0][0]
+    assert "اسیسمنٹ کے وقت گزرنے کی یاد دہانی" in sent_email_od.alternatives[0][0]
     assert "Go to Dashboard" in sent_email_od.alternatives[0][0]
+    assert "ڈیش بورڈ پر جائیں" in sent_email_od.alternatives[0][0]
+
 
 
 @pytest.mark.django_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,9 @@ services:
       EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
       EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD:-}
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-no-reply@psycheversity.com}
-      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <support@psycheversity.com>}
+      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <no-reply@psycheversity.com>}
       PARTICIPANT_EMAIL_REPLY_TO: ${PARTICIPANT_EMAIL_REPLY_TO:-support@psycheversity.com}
-      SITE_BASE_URL: ${SITE_BASE_URL:-http://localhost}
+      SITE_BASE_URL: ${SITE_BASE_URL:-https://psycheversity.com}
       TZ: Asia/Karachi
     depends_on:
       db:
@@ -98,9 +98,9 @@ services:
       EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
       EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD:-}
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-no-reply@psycheversity.com}
-      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <support@psycheversity.com>}
+      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <no-reply@psycheversity.com>}
       PARTICIPANT_EMAIL_REPLY_TO: ${PARTICIPANT_EMAIL_REPLY_TO:-support@psycheversity.com}
-      SITE_BASE_URL: ${SITE_BASE_URL:-http://localhost}
+      SITE_BASE_URL: ${SITE_BASE_URL:-https://psycheversity.com}
       TZ: Asia/Karachi
     depends_on:
       db:
@@ -132,9 +132,9 @@ services:
       EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
       EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD:-}
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-no-reply@psycheversity.com}
-      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <support@psycheversity.com>}
+      PARTICIPANT_EMAIL_FROM: ${PARTICIPANT_EMAIL_FROM:-Psycheversity Research Team <no-reply@psycheversity.com>}
       PARTICIPANT_EMAIL_REPLY_TO: ${PARTICIPANT_EMAIL_REPLY_TO:-support@psycheversity.com}
-      SITE_BASE_URL: ${SITE_BASE_URL:-http://localhost}
+      SITE_BASE_URL: ${SITE_BASE_URL:-https://psycheversity.com}
       TZ: Asia/Karachi
     depends_on:
       db:


### PR DESCRIPTION
This PR introduces fully bilingual assessment due and overdue emails, removes name personalization to avoid the Promotions folder, and routes all notification emails through the unified SMTP helper. All tests pass successfully.