### PR TITLE
security: fix mass assignment, weak OTP, JWT lifetime, and CSV injection

### DIFF
--- a/backend/admin_tools/export_utils.py
+++ b/backend/admin_tools/export_utils.py
@@ -3,6 +3,19 @@ Shared helpers for admin CSV export tasks.
 """
 import re
 
+_FORMULA_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
+
+
+def sanitize_csv_cell(value: str) -> str:
+    """
+    Prevent CSV formula injection by prepending an apostrophe to any cell
+    value that starts with a spreadsheet formula trigger character.
+    Excel/Calc treat the apostrophe-prefixed value as plain text.
+    """
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
 from questionnaires.scoring import (
     PERMA_ITEM_CODES,
     battery_score_column_names,
@@ -56,7 +69,7 @@ def append_psych_item_values(row, resp_map, question_ids):
                 value = str(answer.selected_option.numeric_value)
             else:
                 value = answer.text_value or ""
-            row.append(value.replace("\n", " "))
+            row.append(sanitize_csv_cell(value.replace("\n", " ")))
         else:
             row.append("")
 

--- a/backend/admin_tools/tasks.py
+++ b/backend/admin_tools/tasks.py
@@ -4,6 +4,7 @@ import logging
 from celery import shared_task
 from django.core.files.base import ContentFile
 from .models import ExportTask
+from .export_utils import sanitize_csv_cell
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +278,7 @@ def generate_longitudinal_export_csv(task_id):
                     ans = resp_map.get(q.id)
                     if ans:
                         val = ans.selected_option.label if ans.selected_option else (ans.text_value or '')
-                        row.append(val.replace('\n', ' '))
+                        row.append(sanitize_csv_cell(val.replace('\n', ' ')))
                     else:
                         row.append('')
 
@@ -291,7 +292,7 @@ def generate_longitudinal_export_csv(task_id):
                             val = str(ans.selected_option.numeric_value)
                         else:
                             val = ans.text_value or ''
-                        row.append(val.replace('\n', ' '))
+                        row.append(sanitize_csv_cell(val.replace('\n', ' ')))
                     else:
                         row.append('')
 
@@ -909,7 +910,7 @@ def generate_daily_entries_export_csv(task_id):
                         sub.experiment_day or '',
                         entry_num,
                         count_words(text),
-                        text,
+                        sanitize_csv_cell(text.replace('\n', ' ')),
                         focus_str,
                         submit_str,
                         duration or 0,

--- a/backend/admin_tools/views.py
+++ b/backend/admin_tools/views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
+from .export_utils import sanitize_csv_cell
 from .models import ExportTask
 from .tasks import (
     generate_posttest_export_csv,
@@ -41,7 +42,7 @@ class ExportDataCSVView(APIView):
                 sub.user.group.name if sub.user.group else 'None',
                 sub.user.created_at.strftime('%Y-%m-%d %H:%M:%S'),
                 sub.activity.title,
-                sub.content.replace('\n', ' '), # SPSS friendly: no newlines in text fields
+                sanitize_csv_cell(sub.content.replace('\n', ' ')),
                 sub.submission_date.strftime('%Y-%m-%d %H:%M:%S')
             ])
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -241,7 +241,7 @@ REST_FRAMEWORK = {
 
 # JWT Settings
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=30), # Logged in for 30 days
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=5),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=90),
     'ROTATE_REFRESH_TOKENS': True,
     'ALGORITHM': 'HS256',

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -29,7 +29,8 @@ class UserSerializer(serializers.ModelSerializer):
             'has_two_consecutive_missed_waves', 'is_disqualified',
         )
         read_only_fields = (
-            'created_at', 'has_completed_sociodemographic', 'has_completed_posttest',
+            'created_at', 'role', 'group',
+            'has_completed_sociodemographic', 'has_completed_posttest',
             'is_posttest_due', 'due_milestone', 'current_experiment_day', 'current_activity_wave',
             'has_consecutive_misses',
             'consecutive_misses_message', 'has_two_consecutive_missed_waves', 'is_disqualified',

--- a/backend/users/tests/test_views.py
+++ b/backend/users/tests/test_views.py
@@ -206,6 +206,31 @@ def test_signup_duplicate_username(api_client, db):
     assert "taken" in error_msg or "exists" in error_msg
 
 @pytest.mark.django_db
+def test_profile_patch_cannot_change_role_or_group(authenticated_client, test_user):
+    """Mass assignment protection: role and group must be read-only on the profile endpoint."""
+    from users.models import Role
+    from groups.models import Group
+
+    other_role, _ = Role.objects.get_or_create(name='Admin', defaults={'description': 'Admin role'})
+    other_group, _ = Group.objects.get_or_create(name='OtherGroup')
+
+    original_role_id = test_user.role_id
+    original_group_id = test_user.group_id
+
+    url = reverse('profile')
+    response = authenticated_client.patch(
+        url,
+        {'role': other_role.pk, 'group': other_group.pk},
+        format='json',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    test_user.refresh_from_db()
+    assert test_user.role_id == original_role_id, "role must not be changed via profile PATCH"
+    assert test_user.group_id == original_group_id, "group must not be changed via profile PATCH"
+
+
+@pytest.mark.django_db
 def test_admin_user_list(admin_client, test_user):
     url = reverse('admin_user_list')
     response = admin_client.get(url)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -143,9 +143,8 @@ class SendOTPView(generics.CreateAPIView):
                 return Response({'email': ['User with this email already exists.']}, status=status.HTTP_400_BAD_REQUEST)
         
         from .models import EmailVerificationOTP
-        import random
-        # Generate 6 digit OTP
-        otp = str(random.randint(100000, 999999))
+        import secrets
+        otp = str(secrets.randbelow(900000) + 100000)
         
         # Save to DB
         EmailVerificationOTP.objects.create(email=email, otp=otp)
@@ -181,8 +180,8 @@ class ForgotPasswordRequestView(generics.CreateAPIView):
         from .models import PasswordResetOTP
         PasswordResetOTP.objects.filter(user=user, is_used=False).update(is_used=True)
         
-        import random
-        otp = str(random.randint(100000, 999999))
+        import secrets
+        otp = str(secrets.randbelow(900000) + 100000)
 
         # Create OTP record
         PasswordResetOTP.objects.create(user=user, otp=otp)


### PR DESCRIPTION
## Summary

Four security vulnerabilities identified and fixed across the backend:

- **Mass assignment** — `role` and `group` were writable via the `/api/users/me/` PATCH endpoint. Added both to `read_only_fields` in `UserProfileSerializer` so participants cannot escalate their own privileges.
- **Weak OTP generation** — Both email-verification and password-reset OTPs were generated with `random.randint`, which is not cryptographically secure. Replaced with `secrets.randbelow` (CSPRNG).
- **JWT access token lifetime** — Access tokens were valid for 30 days; reduced to 5 days to limit the exposure window if a token is stolen.
- **CSV formula injection** — Free-text responses were written directly to CSV exports. Added `sanitize_csv_cell()` helper that prepends `'` to any cell starting with `=`, `+`, `-`, `@`, `\t`, or `\r`, preventing formula execution in Excel/LibreOffice. Applied to all three export paths (`export_utils`, `views`, `tasks`).

## Test plan

- [x] Added regression test `test_profile_patch_cannot_change_role_or_group` to assert the mass assignment fix holds
- [x] 260/260 backend tests passing on production VM post-deployment


