### PR TITLE
feat: PERMA snapshot report + seeding fix + questionnaire UI cleanup

### DIFF
--- a/backend/admin_tools/tests/test_battery_export_scoring.py
+++ b/backend/admin_tools/tests/test_battery_export_scoring.py
@@ -119,11 +119,11 @@ def test_posttest_export_includes_all_battery_scores(admin_user, test_group):
     score_start = headers.index("PERMA_PositiveEmotion_SIGNUP")
     exported_scores = data_row[score_start : score_start + len(BATTERY_EXPORT_SCORES)]
 
-    assert exported_scores[9] == "9"    # PHQ9_TOTAL
-    assert exported_scores[10] == "7"   # GAD7_TOTAL
-    assert exported_scores[11] == "4"   # PANAS_PA
-    assert exported_scores[12] == "5"   # PANAS_NA
-    assert exported_scores[13] == "14"  # GRAT_GTO
-    assert exported_scores[14] == "12"  # GRAT_GTA
-    assert exported_scores[15] == "26"  # GRAT_TOTAL
-    assert exported_scores[16] == "11"  # SIDAS_TOTAL
+    assert exported_scores[10] == "9"    # PHQ9_TOTAL  (PERMA_HAP now at index 8, PERMA_OVERALL at 9)
+    assert exported_scores[11] == "7"   # GAD7_TOTAL
+    assert exported_scores[12] == "4"   # PANAS_PA
+    assert exported_scores[13] == "5"   # PANAS_NA
+    assert exported_scores[14] == "14"  # GRAT_GTO
+    assert exported_scores[15] == "12"  # GRAT_GTA
+    assert exported_scores[16] == "26"  # GRAT_TOTAL
+    assert exported_scores[17] == "11"  # SIDAS_TOTAL

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -303,6 +303,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'questionnaires.tasks.refresh_suicide_risk_admin_cache_task',
         'schedule': crontab(hour=3, minute=0),
     },
+    'perma-report-catchup': {
+        'task': 'questionnaires.tasks.check_and_send_perma_reports',
+        'schedule': crontab(hour=8, minute=0),
+    },
 }
 # Spectacular Settings
 SPECTACULAR_SETTINGS = {

--- a/backend/questionnaires/management/commands/seed_longitudinal_scales.py
+++ b/backend/questionnaires/management/commands/seed_longitudinal_scales.py
@@ -670,18 +670,93 @@ class Command(BaseCommand):
         else:
             self.stdout.write(self.style.WARNING(f"'{battery_title}' already exists. Skipping."))
 
-    def _create_questions_for_questionnaire(self, questionnaire, data):
-        for q_data in data:
-            q = Question.objects.create(
-                questionnaire=questionnaire,
-                content=q_data["content"],
-                type=q_data["type"],
-                order=q_data["order"]
-            )
-            for opt_label, opt_val in q_data["options"]:
-                Option.objects.create(
-                    question=q,
-                    label=opt_label,
-                    numeric_value=opt_val,
-                    order=opt_val
-                )
+    def _sync_questions_for_questionnaire(self, questionnaire, data):
+        """
+        Idempotent sync — creates or updates questions identified by order number.
+
+        Algorithm:
+          Pass 1 — move all existing questions to temporary NEGATIVE orders
+                   (avoids unique-order conflicts during the reconcile).
+          Pass 2 — for each desired question:
+                   • if an old question existed at that order, update it in-place
+                     (preserving PK and all linked Response rows).
+                   • otherwise create a fresh Question.
+          Pass 3 — upsert each option by numeric_value (update label; create if new).
+        """
+        from django.db import transaction
+
+        with transaction.atomic():
+            # ── Pass 1: park all existing questions at temp high orders ──────────
+            # (avoids unique-order conflicts during the reconcile; uses offset
+            #  instead of negative values to satisfy CHECK(order >= 0) constraint)
+            TEMP_OFFSET = 10000
+            existing = list(questionnaire.questions.order_by("order"))
+            existing_by_order = {}
+            for q in existing:
+                orig_order = q.order
+                existing_by_order[orig_order] = q
+                q.order = TEMP_OFFSET + orig_order
+                q.save(update_fields=["order"])
+
+            # ── Pass 2: upsert each desired question ─────────────────────────
+            for q_data in data:
+                target_order = q_data["order"]
+                content      = q_data["content"]
+                q_type       = q_data["type"]
+                required     = q_data.get("required", True)
+                options      = q_data.get("options", [])
+
+                old_q = existing_by_order.get(target_order)
+
+                if old_q:
+                    # Update existing record in-place (keeps PK → Response FKs intact)
+                    old_q.order    = target_order
+                    old_q.content  = content
+                    old_q.type     = q_type
+                    old_q.required = required
+                    old_q.save(update_fields=["order", "content", "type", "required"])
+                    q_obj = old_q
+                else:
+                    q_obj = Question.objects.create(
+                        questionnaire=questionnaire,
+                        content=content,
+                        type=q_type,
+                        order=target_order,
+                        required=required,
+                    )
+
+                # ── Pass 3: upsert options by numeric_value ──────────────────
+                existing_opts = {opt.numeric_value: opt for opt in q_obj.options.all()}
+                desired_vals = {opt_val for _, opt_val in options}
+                for opt_label, opt_val in options:
+                    if opt_val in existing_opts:
+                        opt = existing_opts[opt_val]
+                        if opt.label != opt_label:
+                            opt.label = opt_label
+                            opt.save(update_fields=["label"])
+                    else:
+                        Option.objects.create(
+                            question=q_obj,
+                            label=opt_label,
+                            numeric_value=opt_val,
+                            order=opt_val,
+                        )
+
+                # ── Pass 3b: prune stale options not in the desired set ───────
+                # Stale options arise when a question's scale changes (e.g. 0-10
+                # → 0-4 due to order reassignment). Response rows use SET_NULL +
+                # cached selected_option_value so scoring survives the deletion.
+                for stale_val, stale_opt in existing_opts.items():
+                    if stale_val not in desired_vals:
+                        stale_opt.delete()
+
+            # Any remaining questions parked at high temp orders are orphans
+            # (orders no longer in the desired layout). We leave them rather than
+            # deleting, to protect any linked Response data.
+            orphans = questionnaire.questions.filter(order__gte=TEMP_OFFSET)
+            orphan_count = orphans.count()
+            if orphan_count:
+                self.stdout.write(self.style.WARNING(
+                    f"  {orphan_count} orphaned question(s) left at negative orders "
+                    f"(have linked Response data — not deleted)."
+                ))

--- a/backend/questionnaires/management/commands/send_missing_signup_reports.py
+++ b/backend/questionnaires/management/commands/send_missing_signup_reports.py
@@ -1,0 +1,66 @@
+"""
+One-time backfill: send PERMA baseline reports to users who completed T0
+before this feature was deployed.
+
+Usage:
+    python manage.py send_missing_signup_reports
+    python manage.py send_missing_signup_reports --dry-run
+"""
+from django.core.management.base import BaseCommand
+
+from questionnaires.models import ResponseSet, PermaReportLog
+from questionnaires.tasks import send_perma_snapshot_report_task
+
+
+class Command(BaseCommand):
+    help = 'Dispatch PERMA baseline reports for pre-feature T0 completions.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Print who would receive a report without dispatching any tasks.',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+
+        already_sent = set(
+            PermaReportLog.objects.filter(milestone='SIGNUP')
+            .values_list('user_id', flat=True)
+        )
+
+        candidates = (
+            ResponseSet.objects
+            .filter(
+                status='COMPLETED',
+                milestone='SIGNUP',
+                questionnaire__assessment_type='PSYCHOMETRIC',
+            )
+            .exclude(user_id__in=already_sent)
+            .select_related('user')
+        )
+
+        count = candidates.count()
+        if count == 0:
+            self.stdout.write(self.style.SUCCESS('No missing SIGNUP reports found — nothing to do.'))
+            return
+
+        self.stdout.write(f'Found {count} participant(s) missing a baseline report.')
+
+        for rs in candidates:
+            label = f'{rs.user.username} <{rs.user.email}> (ResponseSet {rs.id})'
+            if dry_run:
+                self.stdout.write(f'  [dry-run] would send: {label}')
+            else:
+                send_perma_snapshot_report_task.delay(str(rs.id), 'SIGNUP')
+                self.stdout.write(f'  dispatched: {label}')
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(
+                f'Dry run complete — {count} task(s) NOT dispatched.'
+            ))
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                f'Done — {count} baseline report task(s) dispatched to Celery.'
+            ))

--- a/backend/questionnaires/migrations/0014_permareportlog.py
+++ b/backend/questionnaires/migrations/0014_permareportlog.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('questionnaires', '0013_responseset_suicide_risk_status'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PermaReportLog',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('milestone', models.CharField(max_length=15)),
+                ('status', models.CharField(
+                    choices=[('sent', 'Sent'), ('error', 'Error'), ('skipped', 'Skipped')],
+                    default='sent',
+                    max_length=10,
+                )),
+                ('error_detail', models.TextField(blank=True)),
+                ('sent_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='perma_report_logs',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+            ],
+            options={
+                'unique_together': {('user', 'milestone')},
+            },
+        ),
+    ]

--- a/backend/questionnaires/models.py
+++ b/backend/questionnaires/models.py
@@ -117,6 +117,26 @@ class ResponseSet(models.Model):
     def __str__(self):
         return f"{self.user.username} - {self.questionnaire.title if self.questionnaire else 'Deleted Questionnaire'} ({self.status})"
 
+class PermaReportLog(models.Model):
+    """Audit trail for PERMA snapshot report emails. Enforces never-send-twice."""
+    STATUS_CHOICES = (
+        ('sent', 'Sent'),
+        ('error', 'Error'),
+        ('skipped', 'Skipped'),
+    )
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='perma_report_logs')
+    milestone = models.CharField(max_length=15)
+    status = models.CharField(max_length=10, choices=STATUS_CHOICES, default='sent')
+    error_detail = models.TextField(blank=True)
+    sent_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'milestone')
+
+    def __str__(self):
+        return f"{self.user.username} – {self.milestone} – {self.status}"
+
+
 class Response(models.Model):
     """
     A single answer within a response set.

--- a/backend/questionnaires/scoring.py
+++ b/backend/questionnaires/scoring.py
@@ -24,6 +24,7 @@ PERMA_EXPORT_SCORES = [
     ("PERMA_N", "PERMA_NegativeEmotion"),
     ("PERMA_H", "PERMA_Health"),
     ("PERMA_LON", "PERMA_Loneliness"),
+    ("PERMA_HAP", "PERMA_Happiness"),
     ("PERMA_OVERALL", "PERMA_Overall"),
 ]
 
@@ -96,6 +97,7 @@ def calculate_scores(val_map):
         scores["PERMA_N"] = get_mean(perma_n_orders)
         scores["PERMA_H"] = get_mean(perma_h_orders)
         scores["PERMA_LON"] = float(val_map.get(perma_lon_order, 0.0))
+        scores["PERMA_HAP"] = float(val_map.get(23, 0.0))
         scores["PERMA_OVERALL"] = get_mean(perma_overall_orders)
 
     phq_orders = list(range(24, 33))

--- a/backend/questionnaires/serializers.py
+++ b/backend/questionnaires/serializers.py
@@ -372,6 +372,11 @@ class ResponseSetSubmitSerializer(serializers.ModelSerializer):
                 transaction.on_commit(
                     lambda user_id=user.user_id: send_welcome_email_task.delay(user_id)
                 )
+                # T0 PERMA snapshot report — fire immediately after baseline assessment
+                from questionnaires.tasks import send_perma_snapshot_report_task
+                transaction.on_commit(
+                    lambda rs_id=str(instance.id): send_perma_snapshot_report_task.delay(rs_id, 'SIGNUP')
+                )
 
             if (
                 instance.questionnaire.assessment_type == 'PSYCHOMETRIC'
@@ -387,10 +392,16 @@ class ResponseSetSubmitSerializer(serializers.ModelSerializer):
                     )
                 )
 
-            # Trigger Month-3 PERMA report task if 3_MONTHS milestone of PSYCHOMETRIC questionnaire is completed
-            if instance.milestone == '3_MONTHS' and instance.questionnaire.assessment_type == 'PSYCHOMETRIC':
-                from questionnaires.tasks import send_month_3_report_task
-                transaction.on_commit(lambda: send_month_3_report_task.delay(instance.id))
+            # Trigger PERMA snapshot report for 3_MONTHS and 1_YEAR milestones
+            if (
+                instance.questionnaire.assessment_type == 'PSYCHOMETRIC'
+                and instance.milestone in ('3_MONTHS', '1_YEAR')
+            ):
+                from questionnaires.tasks import send_perma_snapshot_report_task
+                transaction.on_commit(
+                    lambda rs_id=str(instance.id), ms=instance.milestone:
+                        send_perma_snapshot_report_task.delay(rs_id, ms)
+                )
 
         return instance
 

--- a/backend/questionnaires/tasks.py
+++ b/backend/questionnaires/tasks.py
@@ -1,8 +1,268 @@
 import logging
+import io
+import os
+import base64
 
 from celery import shared_task
 
 logger = logging.getLogger(__name__)
+
+NAVY = '#2E4E90'
+GREY = '#7A7A7A'
+
+MILESTONE_SUBJECT = {
+    'SIGNUP':    'Your baseline wellbeing report / آپ کی بیس لائن فلاح رپورٹ',
+    '3_MONTHS':  'Your month-3 wellbeing report / آپ کی تین ماہ فلاح رپورٹ',
+    '1_YEAR':    'Your month-12 wellbeing report / آپ کی بارہ ماہ فلاح رپورٹ',
+}
+
+MILESTONE_FILENAME = {
+    'SIGNUP':   'pims_baseline_report.pdf',
+    '3_MONTHS': 'pims_month3_report.pdf',
+    '1_YEAR':   'pims_month12_report.pdf',
+}
+
+
+def _build_bar_chart(scores):
+    """
+    Generate a single vertical bar chart in PERMA Profiler style.
+    Three groups of bars separated by whitespace:
+      Group 1 – Overall (1 bar, navy)
+      Group 2 – P, E, R, M, A (5 bars, navy)
+      Group 3 – H, Hap, N, Lon (H/Hap navy; N/Lon grey)
+    Y-axis fixed 0–10. Score value printed above every bar.
+    English-only labels on the chart — Urdu lives in the HTML legend
+    (matplotlib cannot shape Arabic/Urdu script correctly).
+    Returns a base64-encoded PNG string.
+    """
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    def _score(key):
+        try:
+            return round(float(scores.get(key, 0.0)), 1)
+        except (TypeError, ValueError):
+            return 0.0
+
+    # All bars in display order, with gaps between groups (None = gap slot)
+    bars_def = [
+        ('Overall', _score('PERMA_OVERALL'), NAVY),
+        (None, None, None),
+        ('P',   _score('PERMA_P'),   NAVY),
+        ('E',   _score('PERMA_E'),   NAVY),
+        ('R',   _score('PERMA_R'),   NAVY),
+        ('M',   _score('PERMA_M'),   NAVY),
+        ('A',   _score('PERMA_A'),   NAVY),
+        (None, None, None),
+        ('H',   _score('PERMA_H'),   NAVY),
+        ('Hap', _score('PERMA_HAP'), NAVY),
+        ('N',   _score('PERMA_N'),   GREY),
+        ('Lon', _score('PERMA_LON'), GREY),
+    ]
+
+    labels = [b[0] if b[0] else '' for b in bars_def]
+    vals   = [b[1] if b[1] is not None else 0.0 for b in bars_def]
+    colors = [b[2] if b[2] else 'none' for b in bars_def]
+    x      = np.arange(len(bars_def))
+
+    fig, ax = plt.subplots(figsize=(8, 4.5), dpi=150)
+
+    for i, (label, val, color) in enumerate(bars_def):
+        if label is None:
+            continue
+        bar = ax.bar(i, val, color=color, width=0.6, edgecolor='none', zorder=3)
+        # Value label above bar
+        ax.text(i, val + 0.18, f'{val}', ha='center', va='bottom',
+                color=color, fontsize=8.5, fontweight='bold')
+
+    ax.set_ylim(0, 10)
+    ax.set_xlim(-0.6, len(bars_def) - 0.4)
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, fontsize=10, color=NAVY, fontweight='bold')
+    ax.set_ylabel('Score (0 – 10)', fontsize=8, color='#555555', labelpad=4)
+    ax.yaxis.set_tick_params(labelsize=9, colors=NAVY)
+
+    # Gridlines on y-axis only
+    ax.yaxis.grid(True, linestyle='--', alpha=0.4, color='#cccccc', zorder=0)
+    ax.set_axisbelow(True)
+
+    # Clean spines
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['left'].set_color('#cccccc')
+    ax.spines['bottom'].set_color(NAVY)
+    ax.tick_params(axis='x', bottom=False)
+
+    # Group separator lines
+    ax.axvline(x=1.5, color='#e0e0e0', linewidth=1, linestyle='-', zorder=1)
+    ax.axvline(x=7.5, color='#e0e0e0', linewidth=1, linestyle='-', zorder=1)
+
+    plt.tight_layout()
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', dpi=150, facecolor='white')
+    plt.close(fig)
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode('utf-8')
+
+
+def _load_logo_base64():
+    """Try common locations for the PIMS logo; return base64 string or empty string."""
+    from django.conf import settings as djsettings
+    candidates = [
+        os.path.join(djsettings.BASE_DIR, 'static', 'pims_logo-removebg.png'),
+        os.path.join(djsettings.BASE_DIR, 'static', 'pims_logo.png'),
+        os.path.join(djsettings.BASE_DIR, 'pims_logo-removebg.png'),
+        os.path.join(os.path.dirname(djsettings.BASE_DIR), 'pims_logo-removebg.png'),
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            try:
+                with open(path, 'rb') as f:
+                    return base64.b64encode(f.read()).decode('utf-8')
+            except OSError:
+                continue
+    return ''
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=300)
+def send_perma_snapshot_report_task(self, response_set_id, milestone):
+    """
+    Generate and email a PERMA snapshot PDF report for a completed assessment.
+    Spec: horizontal bar charts, 3 blocks, bilingual, mandatory support footer.
+    Idempotent: will not send twice for the same user+milestone.
+    """
+    from django.conf import settings as djsettings
+    from django.template.loader import render_to_string
+    from weasyprint import HTML
+    from questionnaires.models import ResponseSet, PermaReportLog
+    from emails.tasks import _send_participant_email
+
+    logger.info("PERMA report: starting for ResponseSet %s milestone=%s", response_set_id, milestone)
+
+    try:
+        response_set = ResponseSet.objects.select_related('user').get(id=response_set_id)
+        user = response_set.user
+
+        if not user.email:
+            logger.error("PERMA report: user %s has no email. Skipping.", user.username)
+            return {'status': 'skipped', 'reason': 'missing_email'}
+
+        # ── Idempotency: skip if already sent ─────────────────────────────────
+        if PermaReportLog.objects.filter(user=user, milestone=milestone).exists():
+            logger.info("PERMA report: already sent for user %s milestone=%s. Skipping.", user.username, milestone)
+            return {'status': 'skipped', 'reason': 'already_sent'}
+
+        scores = response_set.scores or {}
+        if not scores:
+            logger.error("PERMA report: no scores on ResponseSet %s. Skipping.", response_set_id)
+            PermaReportLog.objects.create(user=user, milestone=milestone, status='skipped',
+                                          error_detail='No scores on ResponseSet.')
+            return {'status': 'skipped', 'reason': 'no_scores'}
+
+        # ── Build chart ───────────────────────────────────────────────────────
+        chart_b64 = _build_bar_chart(scores)
+
+        # ── Load logo ─────────────────────────────────────────────────────────
+        logo_b64 = _load_logo_base64()
+
+        # ── Font path for WeasyPrint ──────────────────────────────────────────
+        font_path = os.path.join(djsettings.BASE_DIR, 'static', 'fonts', 'JameelNooriNastaleeq.ttf')
+
+        # ── Milestone display label ───────────────────────────────────────────
+        milestone_labels = {
+            'SIGNUP':   ('Baseline', 'بیس لائن'),
+            '3_MONTHS': ('Month 3',  'تین ماہ'),
+            '1_YEAR':   ('Month 12', 'بارہ ماہ'),
+        }
+        label_en, label_ur = milestone_labels.get(milestone, (milestone, milestone))
+
+        # ── Render HTML → PDF ─────────────────────────────────────────────────
+        context = {
+            'chart_image': chart_b64,
+            'logo_image':  logo_b64,
+            'font_path':   font_path,
+            'label_en':    label_en,
+            'label_ur':    label_ur,
+        }
+        html_string = render_to_string('questionnaires/perma_snapshot_report.html', context)
+        pdf_bytes = HTML(string=html_string).write_pdf()
+
+        # ── Send email ────────────────────────────────────────────────────────
+        subject = MILESTONE_SUBJECT.get(milestone, 'Your wellbeing report')
+        filename = MILESTONE_FILENAME.get(milestone, 'pims_report.pdf')
+
+        _send_participant_email(
+            {
+                'subject': subject,
+                'html_content': (
+                    '<p>Dear Participant,</p>'
+                    '<p>Please find your PERMA Profiler wellbeing report attached.</p>'
+                    '<p dir="rtl" style="text-align:right;font-family:Arial,sans-serif;">'
+                    'عزیز شریک،<br>براہ کرم منسلک PERMA پروفائلر فلاح رپورٹ دیکھیں۔</p>'
+                    '<p>Thank you for your participation.</p>'
+                    '<p dir="rtl" style="text-align:right;font-family:Arial,sans-serif;">'
+                    'آپ کی شرکت کا شکریہ۔</p>'
+                ),
+                'text_content': (
+                    'Dear Participant,\n\n'
+                    'Please find your PERMA Profiler wellbeing report attached.\n\n'
+                    'Thank you for your participation.'
+                ),
+            },
+            user.email,
+            attachments=[(filename, pdf_bytes, 'application/pdf')],
+        )
+
+        # ── Audit log ─────────────────────────────────────────────────────────
+        PermaReportLog.objects.create(user=user, milestone=milestone, status='sent')
+        logger.info("PERMA report: sent to %s for milestone=%s", user.email, milestone)
+        return {'status': 'sent', 'recipient': user.email, 'milestone': milestone}
+
+    except Exception as exc:
+        logger.exception("PERMA report: failed for ResponseSet %s milestone=%s", response_set_id, milestone)
+        try:
+            from questionnaires.models import PermaReportLog, ResponseSet as RS
+            rs = RS.objects.select_related('user').get(id=response_set_id)
+            PermaReportLog.objects.update_or_create(
+                user=rs.user, milestone=milestone,
+                defaults={'status': 'error', 'error_detail': str(exc)},
+            )
+        except Exception:
+            pass
+        raise self.retry(exc=exc)
+
+
+@shared_task
+def check_and_send_perma_reports():
+    """
+    Daily cron: find COMPLETED PSYCHOMETRIC assessments for 3_MONTHS and 1_YEAR
+    that have not yet had a report sent, and fire the report task for each.
+    Acts as a catch-up safety net alongside the event-driven triggers in the serializer.
+    """
+    from questionnaires.models import ResponseSet, PermaReportLog
+
+    report_milestones = ('3_MONTHS', '1_YEAR')
+    qs = ResponseSet.objects.filter(
+        status='COMPLETED',
+        milestone__in=report_milestones,
+        questionnaire__assessment_type='PSYCHOMETRIC',
+    ).select_related('user')
+
+    already_sent_pairs = set(
+        PermaReportLog.objects.filter(milestone__in=report_milestones)
+        .values_list('user_id', 'milestone')
+    )
+
+    dispatched = 0
+    for rs in qs:
+        if (rs.user_id, rs.milestone) not in already_sent_pairs:
+            send_perma_snapshot_report_task.delay(str(rs.id), rs.milestone)
+            dispatched += 1
+
+    logger.info("PERMA report cron: dispatched %d report tasks.", dispatched)
+    return {'dispatched': dispatched}
 
 
 @shared_task
@@ -21,169 +281,3 @@ def refresh_suicide_risk_admin_cache_task():
         "opt_in_count": payload["opt_in_count"],
         "last_refreshed_at": payload["last_refreshed_at"],
     }
-
-
-@shared_task
-def send_month_3_report_task(response_set_id):
-    """
-    Generate and email the Month-3 PERMA trajectory report PDF to the participant.
-    """
-    from questionnaires.models import ResponseSet
-    from django.conf import settings
-    from django.template.loader import render_to_string
-    from django.utils import timezone
-    from weasyprint import HTML
-    import matplotlib
-    matplotlib.use('Agg')
-    import matplotlib.pyplot as plt
-    import io
-    import base64
-
-    logger.info("Starting Month-3 report generation for ResponseSet %s", response_set_id)
-    try:
-        response_set = ResponseSet.objects.select_related('user', 'user__group').get(id=response_set_id)
-        user = response_set.user
-        
-        if not user.email:
-            logger.error("User %s has no email address configured. Skipping report email.", user.username)
-            return {"status": "skipped", "reason": "missing_email"}
-
-        # 1. Fetch completed psychometric response sets for the user
-        milestone_order = ['SIGNUP', '7_DAYS', '1_MONTH', '3_MONTHS']
-        completed_sets = ResponseSet.objects.filter(
-            user=user,
-            status='COMPLETED',
-            milestone__in=milestone_order,
-            questionnaire__assessment_type='PSYCHOMETRIC'
-        )
-
-        scores_by_ms = {rs.milestone: rs.scores for rs in completed_sets if rs.scores}
-        
-        x_labels = []
-        subscales = [
-            ('PERMA_P', 'P'),
-            ('PERMA_E', 'E'),
-            ('PERMA_R', 'R'),
-            ('PERMA_M', 'M'),
-            ('PERMA_A', 'A'),
-            ('PERMA_N', 'N'),
-            ('PERMA_H', 'H'),
-            ('PERMA_LON', 'Lon'),
-            ('PERMA_OVERALL', 'Overall')
-        ]
-        
-        y_values = {key: [] for key, _ in subscales}
-        
-        milestone_mapping = [
-            ('SIGNUP', 'T0'),
-            ('7_DAYS', 'T1'),
-            ('1_MONTH', '1-Month'),
-            ('3_MONTHS', 'T2')
-        ]
-        
-        for ms, label in milestone_mapping:
-            if ms in scores_by_ms:
-                x_labels.append(label)
-                for key, _ in subscales:
-                    val = scores_by_ms[ms].get(key, 0.0)
-                    try:
-                        val = float(val)
-                    except (TypeError, ValueError):
-                        val = 0.0
-                    y_values[key].append(val)
-
-        if not x_labels:
-            logger.error("No PERMA scores found for user %s. Skipping report email.", user.username)
-            return {"status": "skipped", "reason": "no_scores"}
-
-        # 2. Render Matplotlib 3x3 Grid of Line Charts
-        fig, axes = plt.subplots(3, 3, figsize=(9, 9), dpi=300)
-        fig.subplots_adjust(hspace=0.4, wspace=0.3)
-        
-        for idx, (key, label) in enumerate(subscales):
-            row = idx // 3
-            col = idx % 3
-            ax = axes[row, col]
-            
-            ax.plot(
-                x_labels, 
-                y_values[key], 
-                color='#2E4E90', 
-                marker='o', 
-                markersize=5, 
-                linewidth=2.0, 
-                markerfacecolor='#C8A951', 
-                markeredgecolor='#2E4E90'
-            )
-            
-            ax.set_ylim(0, 10.5)
-            ax.spines['top'].set_visible(False)
-            ax.spines['right'].set_visible(False)
-            ax.spines['left'].set_color('#2E4E90')
-            ax.spines['bottom'].set_color('#2E4E90')
-            ax.tick_params(colors='#2E4E90', labelsize=8)
-            ax.grid(axis='y', linestyle='--', alpha=0.5, color='#ccc')
-            ax.set_title(label, color='#2E4E90', fontweight='bold', fontsize=10, pad=6)
-            
-        plt.tight_layout()
-        buf = io.BytesIO()
-        plt.savefig(buf, format='png', bbox_inches='tight', dpi=300)
-        plt.close(fig)
-        buf.seek(0)
-        chart_image_base64 = base64.b64encode(buf.read()).decode('utf-8')
-
-        # Load logo image if exists (try multiple directories and names)
-        import os
-        logo_base64 = ""
-        possible_dirs = [
-            os.path.join(settings.BASE_DIR, 'static'),
-            settings.BASE_DIR,
-            os.path.dirname(settings.BASE_DIR)
-        ]
-        logo_filenames = ['pims_logo.png', 'pims_logo-removebg.png', 'pims_logo.jpg', 'pims_logo.jpeg']
-        found_logo = False
-        for directory in possible_dirs:
-            for filename in logo_filenames:
-                logo_path = os.path.join(directory, filename)
-                if os.path.exists(logo_path):
-                    try:
-                        with open(logo_path, "rb") as f:
-                            logo_base64 = base64.b64encode(f.read()).decode('utf-8')
-                        found_logo = True
-                        logger.info("Found logo at: %s", logo_path)
-                        break
-                    except Exception as logo_err:
-                        logger.warning("Failed to read logo at %s: %s", logo_path, logo_err)
-            if found_logo:
-                break
-
-        # 3. Render HTML template
-        context = {
-            'user_id': user.user_id,
-            'group_name': user.group.name if user.group else 'N/A',
-            'date': timezone.now().strftime('%Y-%m-%d'),
-            'chart_image': chart_image_base64,
-            'logo_image': logo_base64,
-        }
-        html_string = render_to_string('questionnaires/month3_report.html', context)
-
-        # 4. Generate PDF via WeasyPrint
-        pdf_bytes = HTML(string=html_string).write_pdf()
-
-        # 5. Email PDF Attachment using doc-style E8 bilingual template
-        from emails.builder import build_phase_complete_email, get_first_name
-        from emails.tasks import _send_participant_email
-
-        first_name = get_first_name(user)
-        email_content = build_phase_complete_email(first_name, 'phase_3_report')
-        _send_participant_email(
-            email_content,
-            user.email,
-            attachments=[('pims_month3_report.pdf', pdf_bytes, 'application/pdf')],
-        )
-        
-        logger.info("Successfully sent Month-3 report email to user %s (%s)", user.username, user.email)
-        return {"status": "sent", "recipient": user.email}
-    except Exception as e:
-        logger.exception("Failed to generate and send Month-3 report email:")
-        return {"status": "error", "error": str(e)}

--- a/backend/questionnaires/templates/questionnaires/perma_snapshot_report.html
+++ b/backend/questionnaires/templates/questionnaires/perma_snapshot_report.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>PERMA Profiler Wellbeing Report</title>
+<style>
+@page {
+    size: A4 portrait;
+    margin: 14mm 14mm 12mm 14mm;
+}
+
+@font-face {
+    font-family: 'JameelNastaleeq';
+    src: url('file://{{ font_path }}');
+}
+
+* { box-sizing: border-box; }
+
+body {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    color: #18181b;
+    margin: 0;
+    padding: 0;
+    line-height: 1.45;
+    background: #ffffff;
+    font-size: 9pt;
+}
+
+/* ── Header ── */
+.header {
+    border-bottom: 2.5px solid #C8A951;
+    padding-bottom: 7px;
+    margin-bottom: 10px;
+}
+.header-inner {
+    width: 100%;
+    border-collapse: collapse;
+}
+.header-logo-cell {
+    vertical-align: middle;
+    width: 55%;
+}
+.header-logo-cell img {
+    height: 42px;
+    width: auto;
+    display: block;
+}
+.header-wordmark {
+    font-size: 18pt;
+    font-weight: bold;
+    color: #2E4E90;
+    letter-spacing: 1px;
+}
+.header-meta {
+    text-align: right;
+    vertical-align: middle;
+    font-size: 8pt;
+    color: #71717a;
+}
+.header-meta .report-title {
+    font-size: 10pt;
+    font-weight: bold;
+    color: #2E4E90;
+    display: block;
+    margin-bottom: 2px;
+}
+.header-meta .report-title-ur {
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 13pt;
+    color: #2E4E90;
+    display: block;
+    direction: rtl;
+    margin-bottom: 3px;
+}
+
+/* ── Intro strip ── */
+.intro-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 8px;
+    border: 1px solid #e4e4e7;
+    border-radius: 4px;
+}
+.intro-en {
+    width: 50%;
+    padding: 7px 10px;
+    vertical-align: top;
+    border-right: 1px solid #e4e4e7;
+    font-size: 8.5pt;
+    color: #3f3f46;
+}
+.intro-ur {
+    width: 50%;
+    padding: 7px 10px;
+    vertical-align: top;
+    direction: rtl;
+    text-align: right;
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 12pt;
+    color: #3f3f46;
+    line-height: 1.7;
+}
+
+/* ── Chart ── */
+.chart-wrap {
+    text-align: center;
+    margin: 6px 0 8px 0;
+    padding: 6px;
+    border: 1px solid #e4e4e7;
+    background: #fcfcfc;
+}
+.chart-wrap img {
+    width: 100%;
+    max-width: 520px;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+}
+
+/* ── Chart group labels ── */
+.chart-groups {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 4px 0;
+    table-layout: fixed;
+}
+.chart-groups td {
+    text-align: center;
+    padding: 2px 4px;
+    font-size: 8pt;
+    color: #2E4E90;
+    font-weight: bold;
+}
+.chart-groups .grp-ur {
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 11pt;
+    direction: rtl;
+    display: block;
+    color: #2E4E90;
+    margin-top: 1px;
+}
+.chart-groups .grp-sep {
+    border-left: 1px solid #e0e0e0;
+    border-right: 1px solid #e0e0e0;
+}
+
+/* ── Legend table ── */
+.legend-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 7.8pt;
+    margin-bottom: 8px;
+}
+.legend-table th, .legend-table td {
+    border: 1px solid #e4e4e7;
+    padding: 3px 6px;
+    vertical-align: middle;
+}
+.legend-table th {
+    background: #f4f4f5;
+    color: #2E4E90;
+    font-weight: bold;
+}
+.legend-ur {
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 11pt;
+    direction: rtl;
+}
+.legend-grey {
+    color: #7A7A7A;
+}
+.code-col {
+    width: 8%;
+    font-weight: bold;
+    color: #2E4E90;
+}
+.code-col.grey {
+    color: #7A7A7A;
+}
+.desc-col {
+    width: 42%;
+}
+
+/* ── Support footer ── */
+.support-box {
+    border: 1px solid #C8A951;
+    border-radius: 3px;
+    padding: 6px 10px;
+    background: #fffdf5;
+    margin-bottom: 7px;
+}
+.support-box p {
+    margin: 0 0 3px 0;
+    font-size: 8pt;
+    color: #3f3f46;
+}
+.support-box .sup-ur {
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 11.5pt;
+    direction: rtl;
+    text-align: right;
+    color: #3f3f46;
+    display: block;
+    margin-top: 3px;
+}
+
+/* ── Branding footer ── */
+.footer {
+    border-top: 1px solid #e4e4e7;
+    padding-top: 5px;
+    font-size: 7pt;
+    color: #a1a1aa;
+}
+.footer-inner {
+    width: 100%;
+    border-collapse: collapse;
+}
+.footer-left { text-align: left; }
+.footer-right {
+    text-align: right;
+    font-family: 'JameelNastaleeq', serif;
+    font-size: 10pt;
+    direction: rtl;
+    color: #a1a1aa;
+}
+</style>
+</head>
+<body>
+
+<!-- ── Header ─────────────────────────────────────────────────────────── -->
+<div class="header">
+  <table class="header-inner">
+    <tr>
+      <td class="header-logo-cell">
+        {% if logo_image %}
+          <img src="data:image/png;base64,{{ logo_image }}" alt="PIMS Logo">
+        {% else %}
+          <span class="header-wordmark">PIMS</span>
+        {% endif %}
+      </td>
+      <td class="header-meta">
+        <span class="report-title">PERMA Profiler Report &mdash; {{ label_en }}</span>
+        <span class="report-title-ur">PERMA پروفائلر رپورٹ &mdash; {{ label_ur }}</span>
+      </td>
+    </tr>
+  </table>
+</div>
+
+<!-- ── Intro strip ────────────────────────────────────────────────────── -->
+<table class="intro-table">
+  <tr>
+    <td class="intro-en">
+      This report shows your personal PERMA Profiler scores from your
+      <strong>{{ label_en }}</strong> assessment. Scores reflect your own responses
+      and are presented on a 0&ndash;10 scale. Higher scores on P, E, R, M, A, Health,
+      and Happiness indicate greater well-being. Higher scores on Negative Emotion (N)
+      and Loneliness indicate more of those experiences.
+    </td>
+    <td class="intro-ur">
+      یہ رپورٹ آپ کے <strong>{{ label_ur }}</strong> جائزے سے آپ کے ذاتی PERMA پروفائلر
+      اسکور دکھاتی ہے۔ اسکور 0 تا 10 پیمانے پر ہیں۔ P، E، R، M، A، صحت اور خوشی
+      پر زیادہ اسکور زیادہ فلاح ظاہر کرتے ہیں۔ منفی جذبات (N) اور تنہائی پر زیادہ
+      اسکور ان تجربات کی زیادتی ظاہر کرتے ہیں۔
+    </td>
+  </tr>
+</table>
+
+<!-- ── Bar chart ──────────────────────────────────────────────────────── -->
+<div class="chart-wrap">
+  <img src="data:image/png;base64,{{ chart_image }}" alt="PERMA Bar Charts">
+</div>
+
+<!-- ── Chart group labels (bilingual) ────────────────────────────────── -->
+<table class="chart-groups">
+  <tr>
+    <td style="width:12%;">
+      Overall<br><span class="grp-ur">مجموعی</span>
+    </td>
+    <td class="grp-sep" style="width:46%;">
+      Five Pillars<br><span class="grp-ur">پانچ ستون</span>
+    </td>
+    <td style="width:42%;">
+      Additional Measures<br><span class="grp-ur">اضافی پیمائش</span>
+    </td>
+  </tr>
+</table>
+
+<!-- ── Bilingual legend ───────────────────────────────────────────────── -->
+<table class="legend-table">
+  <tr>
+    <th class="code-col">Code</th>
+    <th class="desc-col">Factor / عامل</th>
+    <th class="code-col">Code</th>
+    <th class="desc-col">Factor / عامل</th>
+  </tr>
+  <tr>
+    <td class="code-col">P</td>
+    <td>Positive Emotion &nbsp;/&nbsp; <span class="legend-ur">مثبت جذبات</span></td>
+    <td class="code-col grey">N</td>
+    <td class="legend-grey">Negative Emotion &nbsp;/&nbsp; <span class="legend-ur">منفی جذبات</span></td>
+  </tr>
+  <tr>
+    <td class="code-col">E</td>
+    <td>Engagement &nbsp;/&nbsp; <span class="legend-ur">مشغولیت</span></td>
+    <td class="code-col">H</td>
+    <td>Health &nbsp;/&nbsp; <span class="legend-ur">صحت</span></td>
+  </tr>
+  <tr>
+    <td class="code-col">R</td>
+    <td>Relationships &nbsp;/&nbsp; <span class="legend-ur">تعلقات</span></td>
+    <td class="code-col grey">Lon</td>
+    <td class="legend-grey">Loneliness &nbsp;/&nbsp; <span class="legend-ur">تنہائی</span></td>
+  </tr>
+  <tr>
+    <td class="code-col">M</td>
+    <td>Meaning &nbsp;/&nbsp; <span class="legend-ur">مقصدِ زندگی</span></td>
+    <td class="code-col">Hap</td>
+    <td>Happiness &nbsp;/&nbsp; <span class="legend-ur">خوشی</span></td>
+  </tr>
+  <tr>
+    <td class="code-col">A</td>
+    <td>Accomplishment &nbsp;/&nbsp; <span class="legend-ur">کامیابی</span></td>
+    <td class="code-col">Overall</td>
+    <td>Overall Well-being &nbsp;/&nbsp; <span class="legend-ur">مجموعی فلاح</span></td>
+  </tr>
+</table>
+
+<!-- ── Support footer (MANDATORY – do not remove) ────────────────────── -->
+<div class="support-box">
+  <p>
+    <strong>Support:</strong> If you feel distressed, please reach out to your research team
+    at <strong>support@psycheversity.com</strong> &nbsp;|&nbsp;
+    Pakistan helpline: <strong>Umang 0317-4288665</strong>
+  </p>
+  <span class="sup-ur">
+    <strong>مدد:</strong> اگر آپ پریشانی محسوس کریں تو براہ کرم اپنی تحقیقاتی ٹیم سے رابطہ کریں:
+    <strong>support@psycheversity.com</strong> &nbsp;|&nbsp;
+    پاکستان ہیلپ لائن: <strong>امنگ 0317-4288665</strong>
+  </span>
+</div>
+
+<!-- ── Branding footer ────────────────────────────────────────────────── -->
+<div class="footer">
+  <table class="footer-inner">
+    <tr>
+      <td class="footer-left">
+        Pakistan Institute of Mind Sciences (PIMS) &nbsp;&bull;&nbsp;
+        Est. 2018 &nbsp;&bull;&nbsp; www.pimscourse.com
+      </td>
+      <td class="footer-right">
+        پاکستان انسٹیٹیوٹ آف مائنڈ سائنسز
+      </td>
+    </tr>
+  </table>
+</div>
+
+</body>
+</html>

--- a/backend/questionnaires/tests/test_month3_report.py
+++ b/backend/questionnaires/tests/test_month3_report.py
@@ -1,3 +1,8 @@
+"""
+Legacy month-3 report tests — migrated to use send_perma_snapshot_report_task.
+Comprehensive coverage has moved to test_perma_report.py.
+These tests are kept for continuity and verify the 3_MONTHS milestone path specifically.
+"""
 import pytest
 from django.core import mail
 from django.utils import timezone
@@ -5,13 +10,15 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from users.models import User, Role
-from questionnaires.models import Questionnaire, Question, Option, ResponseSet, Response
-from questionnaires.tasks import send_month_3_report_task
+from questionnaires.models import Questionnaire, Question, Option, ResponseSet, Response, PermaReportLog
+from questionnaires.tasks import send_perma_snapshot_report_task
 from questionnaires.serializers import ResponseSetSubmitSerializer
+
 
 @pytest.fixture
 def participant_role(db):
     return Role.objects.get_or_create(name='Participant')[0]
+
 
 @pytest.fixture
 def user(db, participant_role):
@@ -21,230 +28,100 @@ def user(db, participant_role):
         password='password123',
         role=participant_role,
         has_completed_sociodemographic=True,
-        onboarding_completed_at=timezone.now() - timedelta(days=90)
+        onboarding_completed_at=timezone.now() - timedelta(days=90),
     )
+
 
 @pytest.fixture
 def psych_questionnaire(db):
-    q = Questionnaire.objects.create(
+    return Questionnaire.objects.create(
         title='Psychometric Battery',
         assessment_type='PSYCHOMETRIC',
-        is_active=True
+        is_active=True,
     )
-    # Create a dummy question
-    Question.objects.create(questionnaire=q, content='PERMA Q1', type='SCALE', order=1)
-    return q
+
+
+SCORES_3M = {
+    'PERMA_P': 8.2, 'PERMA_E': 8.4, 'PERMA_R': 8.0, 'PERMA_M': 8.5,
+    'PERMA_A': 8.3, 'PERMA_N': 2.5, 'PERMA_H': 8.5, 'PERMA_LON': 2.0,
+    'PERMA_HAP': 8.0, 'PERMA_OVERALL': 8.5,
+}
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMonth3Report:
 
     def test_report_generation_and_email(self, user, psych_questionnaire):
-        # 1. Create completed response sets with scores for SIGNUP, 7_DAYS, 1_MONTH
-        rs_signup = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='SIGNUP',
-            scores={
-                'PERMA_P': 6.0, 'PERMA_E': 6.2, 'PERMA_R': 5.8, 'PERMA_M': 6.5,
-                'PERMA_A': 6.1, 'PERMA_N': 4.0, 'PERMA_H': 7.0, 'PERMA_LON': 3.5,
-                'PERMA_OVERALL': 6.5
-            },
-            completed_at=timezone.now() - timedelta(days=90)
-        )
-        rs_7days = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='7_DAYS',
-            scores={
-                'PERMA_P': 6.8, 'PERMA_E': 7.0, 'PERMA_R': 6.5, 'PERMA_M': 7.2,
-                'PERMA_A': 6.9, 'PERMA_N': 3.5, 'PERMA_H': 7.5, 'PERMA_LON': 3.0,
-                'PERMA_OVERALL': 7.2
-            },
-            completed_at=timezone.now() - timedelta(days=83)
-        )
-        rs_1month = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='1_MONTH',
-            scores={
-                'PERMA_P': 7.5, 'PERMA_E': 7.6, 'PERMA_R': 7.2, 'PERMA_M': 7.8,
-                'PERMA_A': 7.5, 'PERMA_N': 3.0, 'PERMA_H': 8.0, 'PERMA_LON': 2.5,
-                'PERMA_OVERALL': 7.8
-            },
-            completed_at=timezone.now() - timedelta(days=60)
-        )
         rs_3months = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='3_MONTHS',
-            scores={
-                'PERMA_P': 8.2, 'PERMA_E': 8.4, 'PERMA_R': 8.0, 'PERMA_M': 8.5,
-                'PERMA_A': 8.3, 'PERMA_N': 2.5, 'PERMA_H': 8.5, 'PERMA_LON': 2.0,
-                'PERMA_OVERALL': 8.5
-            },
-            completed_at=timezone.now()
+            user=user, questionnaire=psych_questionnaire,
+            status='COMPLETED', milestone='3_MONTHS',
+            scores=SCORES_3M, completed_at=timezone.now(),
         )
+        mail.outbox.clear()
 
-        # 2. Run the task synchronously
-        res = send_month_3_report_task(rs_3months.id)
-        
+        res = send_perma_snapshot_report_task.apply(args=[str(rs_3months.id), '3_MONTHS']).get()
+
         assert res['status'] == 'sent'
         assert res['recipient'] == 'participant@test.com'
 
-        # 3. Assert email is in outbox
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
         assert email.to == ['participant@test.com']
-        assert "Phase complete" in email.subject
-        assert "wellbeing summary" in email.subject
-        assert "You have completed this phase" in email.body
-        assert "PERMA Profiler" in email.body
-        assert "following phase will begin" in email.body
-        assert "آپ نے یہ مرحلہ مکمل کر لیا ہے" in email.body
-
-        # 4. Assert PDF attachment is present
+        assert 'month-3' in email.subject.lower()
         assert len(email.attachments) == 1
-        attachment_name, attachment_data, mime_type = email.attachments[0]
-        assert attachment_name == "pims_month3_report.pdf"
-        assert mime_type == "application/pdf"
-        assert len(attachment_data) > 0  # Assert it's non-empty PDF bytes
+        fname, pdf_data, mime = email.attachments[0]
+        assert fname == 'pims_month3_report.pdf'
+        assert mime == 'application/pdf'
+        assert len(pdf_data) > 0
 
-    @patch('questionnaires.tasks.send_month_3_report_task.delay')
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
     def test_submission_triggers_month3_report_task(self, mock_delay, user, psych_questionnaire):
-        # Create a draft response set for 3_MONTHS
         rs = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='DRAFT',
-            milestone='3_MONTHS'
+            user=user, questionnaire=psych_questionnaire,
+            status='DRAFT', milestone='3_MONTHS',
         )
-
-        # Submit it using ResponseSetSubmitSerializer
-        data = {
-            'responses_data': []
-        }
-        
-        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        serializer = ResponseSetSubmitSerializer(instance=rs, data={'responses_data': []})
         assert serializer.is_valid(), serializer.errors
         serializer.save()
-
-        # Check that the celery delay task was triggered
-        mock_delay.assert_called_once_with(rs.id)
-
-    def test_report_generation_with_missing_milestones(self, user, psych_questionnaire):
-        # Only SIGNUP and 3_MONTHS completed (7_DAYS and 1_MONTH are missing)
-        rs_signup = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='SIGNUP',
-            scores={
-                'PERMA_P': 6.0, 'PERMA_E': 6.2, 'PERMA_R': 5.8, 'PERMA_M': 6.5,
-                'PERMA_A': 6.1, 'PERMA_N': 4.0, 'PERMA_H': 7.0, 'PERMA_LON': 3.5,
-                'PERMA_OVERALL': 6.5
-            },
-            completed_at=timezone.now() - timedelta(days=90)
-        )
-        rs_3months = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='3_MONTHS',
-            scores={
-                'PERMA_P': 8.2, 'PERMA_E': 8.4, 'PERMA_R': 8.0, 'PERMA_M': 8.5,
-                'PERMA_A': 8.3, 'PERMA_N': 2.5, 'PERMA_H': 8.5, 'PERMA_LON': 2.0,
-                'PERMA_OVERALL': 8.5
-            },
-            completed_at=timezone.now()
-        )
-
-        mail.outbox.clear()
-        res = send_month_3_report_task(rs_3months.id)
-        assert res['status'] == 'sent'
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert len(email.attachments) == 1
-        assert email.attachments[0][0] == "pims_month3_report.pdf"
-
-    def test_report_generation_with_malformed_scores(self, user, psych_questionnaire):
-        # Signup has invalid score formats (strings or None)
-        rs_signup = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='SIGNUP',
-            scores={
-                'PERMA_P': 'invalid_string', 'PERMA_E': 6.2, 'PERMA_R': 5.8, 'PERMA_M': None,
-                'PERMA_A': 6.1, 'PERMA_N': 4.0, 'PERMA_H': 7.0, 'PERMA_LON': 3.5,
-                'PERMA_OVERALL': 6.5
-            },
-            completed_at=timezone.now() - timedelta(days=90)
-        )
-        rs_3months = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='3_MONTHS',
-            scores={
-                'PERMA_P': 8.2, 'PERMA_E': 8.4, 'PERMA_R': 8.0, 'PERMA_M': 8.5,
-                'PERMA_A': 8.3, 'PERMA_N': 2.5, 'PERMA_H': 8.5, 'PERMA_LON': 2.0,
-                'PERMA_OVERALL': 8.5
-            },
-            completed_at=timezone.now()
-        )
-
-        mail.outbox.clear()
-        res = send_month_3_report_task(rs_3months.id)
-        assert res['status'] == 'sent'
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert len(email.attachments) == 1
+        mock_delay.assert_called_once_with(str(rs.id), '3_MONTHS')
 
     def test_report_generation_skipped_if_no_scores(self, user, psych_questionnaire):
-        # User has completed sets but scores is empty dict
-        rs_signup = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='SIGNUP',
-            scores={},
-            completed_at=timezone.now() - timedelta(days=90)
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_questionnaire,
+            status='COMPLETED', milestone='3_MONTHS',
+            scores={}, completed_at=timezone.now(),
         )
-        rs_3months = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='3_MONTHS',
-            scores={},
-            completed_at=timezone.now()
-        )
-
         mail.outbox.clear()
-        res = send_month_3_report_task(rs_3months.id)
+
+        res = send_perma_snapshot_report_task.apply(args=[str(rs.id), '3_MONTHS']).get()
         assert res['status'] == 'skipped'
         assert res['reason'] == 'no_scores'
         assert len(mail.outbox) == 0
 
     def test_report_generation_skipped_if_no_email(self, user, psych_questionnaire):
-        # Set user email to empty string
-        user.email = ""
+        user.email = ''
         user.save()
-
-        rs_3months = ResponseSet.objects.create(
-            user=user,
-            questionnaire=psych_questionnaire,
-            status='COMPLETED',
-            milestone='3_MONTHS',
-            scores={'PERMA_OVERALL': 8.5},
-            completed_at=timezone.now()
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_questionnaire,
+            status='COMPLETED', milestone='3_MONTHS',
+            scores=SCORES_3M, completed_at=timezone.now(),
         )
-
         mail.outbox.clear()
-        res = send_month_3_report_task(rs_3months.id)
+
+        res = send_perma_snapshot_report_task.apply(args=[str(rs.id), '3_MONTHS']).get()
         assert res['status'] == 'skipped'
         assert res['reason'] == 'missing_email'
         assert len(mail.outbox) == 0
+
+    def test_report_generation_with_malformed_scores(self, user, psych_questionnaire):
+        bad = dict(SCORES_3M, PERMA_P='invalid_string', PERMA_M=None)
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_questionnaire,
+            status='COMPLETED', milestone='3_MONTHS',
+            scores=bad, completed_at=timezone.now(),
+        )
+        mail.outbox.clear()
+
+        res = send_perma_snapshot_report_task.apply(args=[str(rs.id), '3_MONTHS']).get()
+        assert res['status'] == 'sent'
+        assert len(mail.outbox) == 1

--- a/backend/questionnaires/tests/test_onboarding_flow.py
+++ b/backend/questionnaires/tests/test_onboarding_flow.py
@@ -106,9 +106,11 @@ def test_sociodemographic_submission_completes_onboarding(fresh_client, fresh_us
 
     fresh_user.refresh_from_db()
     assert fresh_user.onboarding_completed_at is not None  # Now onboarding is fully complete
-    assert len(mail.outbox) == 1
-    welcome = mail.outbox[0]
-    assert 'Welcome to Psycheversity' in welcome.subject
+    # Welcome email + PERMA baseline report email are both sent on SIGNUP completion
+    assert len(mail.outbox) == 2
+    subjects = [m.subject for m in mail.outbox]
+    assert any('Welcome to Psycheversity' in s for s in subjects)
+    welcome = next(m for m in mail.outbox if 'Welcome to Psycheversity' in m.subject)
     assert 'سائیکیورسٹی میں خوش آمدید' in welcome.subject
     assert welcome.to == [fresh_user.email]
 

--- a/backend/questionnaires/tests/test_perma_report.py
+++ b/backend/questionnaires/tests/test_perma_report.py
@@ -1,0 +1,492 @@
+"""
+Tests for the PERMA snapshot report feature.
+
+Covers:
+  - send_perma_snapshot_report_task (happy path, all milestones)
+  - Idempotency: never sends twice for same user+milestone
+  - Skip conditions: no email, no scores
+  - Audit log (PermaReportLog) creation on success, skip, and error
+  - check_and_send_perma_reports daily cron
+  - _build_bar_chart: returns valid PNG, handles zero/malformed scores
+  - Scoring: PERMA_HAP stored and exported
+  - Serializer event-driven triggers for SIGNUP, 3_MONTHS, 1_YEAR
+"""
+import base64
+import pytest
+from unittest.mock import patch, MagicMock
+from django.core import mail
+from django.utils import timezone
+from datetime import timedelta
+
+from users.models import User, Role
+from questionnaires.models import Questionnaire, Question, ResponseSet, PermaReportLog
+from questionnaires.tasks import (
+    send_perma_snapshot_report_task,
+    check_and_send_perma_reports,
+    _build_bar_chart,
+)
+from questionnaires.scoring import calculate_scores, PERMA_EXPORT_SCORES
+
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def participant_role(db):
+    return Role.objects.get_or_create(name='Participant')[0]
+
+
+@pytest.fixture
+def user(db, participant_role):
+    return User.objects.create_user(
+        username='perma_test_user',
+        email='permauser@test.com',
+        password='testpass123',
+        role=participant_role,
+        has_completed_sociodemographic=True,
+        onboarding_completed_at=timezone.now() - timedelta(days=90),
+    )
+
+
+@pytest.fixture
+def user_no_email(db, participant_role):
+    return User.objects.create_user(
+        username='no_email_user',
+        email='',
+        password='testpass123',
+        role=participant_role,
+        has_completed_sociodemographic=True,
+    )
+
+
+@pytest.fixture
+def psych_q(db):
+    return Questionnaire.objects.create(
+        title='Psychometric Battery',
+        assessment_type='PSYCHOMETRIC',
+        is_active=True,
+    )
+
+
+SAMPLE_SCORES = {
+    'PERMA_P': 7.0, 'PERMA_E': 6.5, 'PERMA_R': 7.5, 'PERMA_M': 8.0,
+    'PERMA_A': 6.0, 'PERMA_N': 3.5, 'PERMA_H': 7.2, 'PERMA_LON': 2.8,
+    'PERMA_HAP': 7.0, 'PERMA_OVERALL': 7.1,
+}
+
+
+def _make_rs(user, psych_q, milestone, scores=None):
+    return ResponseSet.objects.create(
+        user=user,
+        questionnaire=psych_q,
+        status='COMPLETED',
+        milestone=milestone,
+        scores=scores if scores is not None else SAMPLE_SCORES,
+        completed_at=timezone.now(),
+    )
+
+
+# ── _build_bar_chart ───────────────────────────────────────────────────────────
+
+class TestBuildBarChart:
+
+    def test_returns_valid_base64_png(self):
+        b64 = _build_bar_chart(SAMPLE_SCORES)
+        assert isinstance(b64, str)
+        assert len(b64) > 0
+        raw = base64.b64decode(b64)
+        # PNG magic bytes
+        assert raw[:8] == b'\x89PNG\r\n\x1a\n'
+
+    def test_handles_all_scores_missing(self):
+        """All scores absent → treat as zero, must not raise."""
+        b64 = _build_bar_chart({})
+        assert len(b64) > 0
+        assert base64.b64decode(b64)[:4] == b'\x89PNG'
+
+    def test_handles_malformed_score_values(self):
+        """String / None values must fall back to 0.0 without crashing."""
+        bad_scores = {
+            'PERMA_P': 'not_a_number', 'PERMA_E': None, 'PERMA_R': 7.0,
+            'PERMA_M': 8.0, 'PERMA_A': 6.0, 'PERMA_N': 3.5,
+            'PERMA_H': 7.2, 'PERMA_LON': 2.8, 'PERMA_HAP': 7.0, 'PERMA_OVERALL': 7.1,
+        }
+        b64 = _build_bar_chart(bad_scores)
+        assert len(b64) > 0
+
+    def test_perma_hap_is_included_in_block3(self):
+        """PERMA_HAP (Happiness) must appear in the additional-measures block."""
+        # We can't easily inspect bar positions, but we ensure the function
+        # reads PERMA_HAP without KeyError and produces a chart.
+        scores_with_hap = dict(SAMPLE_SCORES, PERMA_HAP=9.5)
+        b64 = _build_bar_chart(scores_with_hap)
+        assert len(b64) > 0
+
+
+# ── PERMA scoring: PERMA_HAP ──────────────────────────────────────────────────
+
+class TestScoringPermaHap:
+
+    def test_perma_hap_stored_from_item_23(self):
+        val_map = {i: float(i % 10) for i in range(1, 24)}
+        val_map[23] = 8.0  # Hap item
+        scores = calculate_scores(val_map)
+        assert 'PERMA_HAP' in scores
+        assert scores['PERMA_HAP'] == 8.0
+
+    def test_perma_hap_zero_when_item_23_absent(self):
+        val_map = {i: 5.0 for i in range(1, 23)}  # no item 23
+        scores = calculate_scores(val_map)
+        assert scores.get('PERMA_HAP', 0.0) == 0.0
+
+    def test_perma_hap_in_export_scores(self):
+        export_keys = [key for key, _ in PERMA_EXPORT_SCORES]
+        assert 'PERMA_HAP' in export_keys
+
+    def test_perma_hap_before_overall_in_export(self):
+        keys = [key for key, _ in PERMA_EXPORT_SCORES]
+        assert keys.index('PERMA_HAP') < keys.index('PERMA_OVERALL')
+
+
+# ── PermaReportLog model ───────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestPermaReportLog:
+
+    def test_default_status_is_sent(self, user):
+        log = PermaReportLog.objects.create(user=user, milestone='SIGNUP')
+        assert log.status == 'sent'
+
+    def test_unique_together_prevents_duplicate(self, user):
+        from django.db import IntegrityError
+        PermaReportLog.objects.create(user=user, milestone='SIGNUP')
+        with pytest.raises(IntegrityError):
+            PermaReportLog.objects.create(user=user, milestone='SIGNUP')
+
+    def test_different_milestones_allowed(self, user):
+        PermaReportLog.objects.create(user=user, milestone='SIGNUP')
+        PermaReportLog.objects.create(user=user, milestone='3_MONTHS')
+        assert PermaReportLog.objects.filter(user=user).count() == 2
+
+
+# ── send_perma_snapshot_report_task ───────────────────────────────────────────
+
+@pytest.mark.django_db(transaction=True)
+class TestSendPermaSnapshotReportTask:
+
+    # ── Happy path per milestone ──────────────────────────────────────────────
+
+    @pytest.mark.parametrize('milestone,expected_filename,expected_subject_part', [
+        ('SIGNUP',    'pims_baseline_report.pdf',  'baseline'),
+        ('3_MONTHS',  'pims_month3_report.pdf',    'month-3'),
+        ('1_YEAR',    'pims_month12_report.pdf',   'month-12'),
+    ])
+    def test_sends_email_with_pdf_for_each_milestone(
+        self, user, psych_q, milestone, expected_filename, expected_subject_part
+    ):
+        rs = _make_rs(user, psych_q, milestone)
+        mail.outbox.clear()
+
+        result = send_perma_snapshot_report_task.apply(args=[str(rs.id), milestone]).get()
+
+        assert result['status'] == 'sent'
+        assert result['recipient'] == user.email
+        assert result['milestone'] == milestone
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.to == [user.email]
+        assert expected_subject_part.lower() in sent.subject.lower()
+
+        assert len(sent.attachments) == 1
+        fname, pdf_data, mime = sent.attachments[0]
+        assert fname == expected_filename
+        assert mime == 'application/pdf'
+        assert len(pdf_data) > 0
+
+    def test_audit_log_created_on_success(self, user, psych_q):
+        rs = _make_rs(user, psych_q, 'SIGNUP')
+        send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+
+        log = PermaReportLog.objects.get(user=user, milestone='SIGNUP')
+        assert log.status == 'sent'
+        assert log.error_detail == ''
+
+    # ── No-email skip ─────────────────────────────────────────────────────────
+
+    def test_skips_when_user_has_no_email(self, user_no_email, psych_q):
+        rs = _make_rs(user_no_email, psych_q, 'SIGNUP')
+        mail.outbox.clear()
+
+        result = send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+
+        assert result['status'] == 'skipped'
+        assert result['reason'] == 'missing_email'
+        assert len(mail.outbox) == 0
+
+    # ── No-scores skip ────────────────────────────────────────────────────────
+
+    def test_skips_and_logs_when_scores_empty(self, user, psych_q):
+        rs = _make_rs(user, psych_q, '3_MONTHS', scores={})
+        mail.outbox.clear()
+
+        result = send_perma_snapshot_report_task.apply(args=[str(rs.id), '3_MONTHS']).get()
+
+        assert result['status'] == 'skipped'
+        assert result['reason'] == 'no_scores'
+        assert len(mail.outbox) == 0
+
+        log = PermaReportLog.objects.get(user=user, milestone='3_MONTHS')
+        assert log.status == 'skipped'
+
+    # ── Idempotency ───────────────────────────────────────────────────────────
+
+    def test_does_not_send_twice_for_same_milestone(self, user, psych_q):
+        rs = _make_rs(user, psych_q, 'SIGNUP')
+        mail.outbox.clear()
+
+        send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+        first_count = len(mail.outbox)
+
+        # Second call must be a no-op
+        result = send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+
+        assert result['status'] == 'skipped'
+        assert result['reason'] == 'already_sent'
+        assert len(mail.outbox) == first_count  # no new email
+
+    def test_different_milestones_send_independently(self, user, psych_q):
+        rs_signup = _make_rs(user, psych_q, 'SIGNUP')
+        rs_3m = _make_rs(user, psych_q, '3_MONTHS')
+        mail.outbox.clear()
+
+        send_perma_snapshot_report_task.apply(args=[str(rs_signup.id), 'SIGNUP']).get()
+        send_perma_snapshot_report_task.apply(args=[str(rs_3m.id), '3_MONTHS']).get()
+
+        assert len(mail.outbox) == 2
+        assert PermaReportLog.objects.filter(user=user).count() == 2
+
+    # ── Malformed scores must not crash ───────────────────────────────────────
+
+    def test_handles_malformed_scores_without_crash(self, user, psych_q):
+        bad_scores = {
+            'PERMA_P': 'invalid', 'PERMA_E': None, 'PERMA_R': 7.0,
+            'PERMA_M': 8.0, 'PERMA_A': 6.0, 'PERMA_N': 3.5,
+            'PERMA_H': 7.2, 'PERMA_LON': 2.8, 'PERMA_HAP': 7.0, 'PERMA_OVERALL': 7.1,
+        }
+        rs = _make_rs(user, psych_q, 'SIGNUP', scores=bad_scores)
+        mail.outbox.clear()
+
+        result = send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+        assert result['status'] == 'sent'
+        assert len(mail.outbox) == 1
+
+    # ── Report content constraints ────────────────────────────────────────────
+
+    def test_email_body_contains_no_score_values(self, user, psych_q):
+        """Scores must live in the PDF only, not in the email body."""
+        rs = _make_rs(user, psych_q, '3_MONTHS')
+        mail.outbox.clear()
+
+        send_perma_snapshot_report_task.apply(args=[str(rs.id), '3_MONTHS']).get()
+        body = mail.outbox[0].body
+        # None of the actual numeric score values should appear in the plain-text body
+        for score_val in ['7.0', '6.5', '7.5', '8.0', '3.5', '7.2', '2.8', '7.1']:
+            assert score_val not in body
+
+    def test_subject_is_neutral_same_for_all_participants(self, user, psych_q):
+        """Subject must not contain evaluative language."""
+        for milestone in ('SIGNUP', '3_MONTHS', '1_YEAR'):
+            rs = ResponseSet.objects.create(
+                user=user, questionnaire=psych_q, status='COMPLETED',
+                milestone=milestone, scores=SAMPLE_SCORES, completed_at=timezone.now(),
+            )
+            mail.outbox.clear()
+            send_perma_snapshot_report_task.apply(args=[str(rs.id), milestone]).get()
+            subject = mail.outbox[0].subject.lower()
+            for forbidden in ('high', 'low', 'good', 'poor', 'flourish', 'languish'):
+                assert forbidden not in subject, f"Forbidden word '{forbidden}' in subject: {subject}"
+            PermaReportLog.objects.filter(user=user, milestone=milestone).delete()
+
+    def test_pdf_attachment_is_non_empty(self, user, psych_q):
+        rs = _make_rs(user, psych_q, 'SIGNUP')
+        mail.outbox.clear()
+
+        send_perma_snapshot_report_task.apply(args=[str(rs.id), 'SIGNUP']).get()
+        _, pdf_data, _ = mail.outbox[0].attachments[0]
+        # WeasyPrint PDFs start with %PDF
+        assert pdf_data[:4] == b'%PDF'
+
+
+# ── check_and_send_perma_reports (daily cron) ────────────────────────────────
+
+@pytest.mark.django_db
+class TestCheckAndSendPermaReports:
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_dispatches_for_unreported_3_months(self, mock_delay, user, psych_q):
+        rs = _make_rs(user, psych_q, '3_MONTHS')
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 1
+        mock_delay.assert_called_once_with(str(rs.id), '3_MONTHS')
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_dispatches_for_unreported_1_year(self, mock_delay, user, psych_q):
+        rs = _make_rs(user, psych_q, '1_YEAR')
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 1
+        mock_delay.assert_called_once_with(str(rs.id), '1_YEAR')
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_skips_already_sent(self, mock_delay, user, psych_q):
+        rs = _make_rs(user, psych_q, '3_MONTHS')
+        PermaReportLog.objects.create(user=user, milestone='3_MONTHS', status='sent')
+
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 0
+        mock_delay.assert_not_called()
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_does_not_dispatch_for_signup_milestone(self, mock_delay, user, psych_q):
+        """SIGNUP reports are event-driven; cron must not re-dispatch them."""
+        _make_rs(user, psych_q, 'SIGNUP')
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 0
+        mock_delay.assert_not_called()
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_does_not_dispatch_for_draft_response_sets(self, mock_delay, user, psych_q):
+        ResponseSet.objects.create(
+            user=user, questionnaire=psych_q, status='DRAFT',
+            milestone='3_MONTHS', scores=SAMPLE_SCORES,
+        )
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 0
+        mock_delay.assert_not_called()
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_dispatches_multiple_users(self, mock_delay, psych_q, participant_role):
+        users = [
+            User.objects.create_user(
+                username=f'multi_user_{i}', email=f'multi{i}@test.com',
+                password='pw', role=participant_role,
+            )
+            for i in range(3)
+        ]
+        for u in users:
+            _make_rs(u, psych_q, '3_MONTHS')
+
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 3
+        assert mock_delay.call_count == 3
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_partial_sent_dispatches_only_unsent(self, mock_delay, psych_q, participant_role):
+        """If 2 of 3 users already sent, only dispatch the remaining 1."""
+        users = [
+            User.objects.create_user(
+                username=f'partial_user_{i}', email=f'partial{i}@test.com',
+                password='pw', role=participant_role,
+            )
+            for i in range(3)
+        ]
+        rss = [_make_rs(u, psych_q, '3_MONTHS') for u in users]
+        # Mark first 2 as already sent
+        PermaReportLog.objects.create(user=users[0], milestone='3_MONTHS', status='sent')
+        PermaReportLog.objects.create(user=users[1], milestone='3_MONTHS', status='sent')
+
+        result = check_and_send_perma_reports()
+        assert result['dispatched'] == 1
+        mock_delay.assert_called_once_with(str(rss[2].id), '3_MONTHS')
+
+
+# ── Serializer event-driven triggers ─────────────────────────────────────────
+
+@pytest.mark.django_db(transaction=True)
+class TestSerializerTriggers:
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_signup_completion_triggers_report(self, mock_delay, user, psych_q):
+        from questionnaires.serializers import ResponseSetSubmitSerializer
+
+        psych_q.assessment_type = 'PSYCHOMETRIC'
+        psych_q.save()
+
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_q, status='DRAFT', milestone='SIGNUP',
+        )
+        # Mark onboarding not yet done so is_new_onboarding = True
+        user.onboarding_completed_at = None
+        user.save()
+
+        data = {'responses_data': []}
+        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        mock_delay.assert_called_once_with(str(rs.id), 'SIGNUP')
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_3months_completion_triggers_report(self, mock_delay, user, psych_q):
+        from questionnaires.serializers import ResponseSetSubmitSerializer
+
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_q, status='DRAFT', milestone='3_MONTHS',
+        )
+        data = {'responses_data': []}
+        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        mock_delay.assert_called_once_with(str(rs.id), '3_MONTHS')
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_1year_completion_triggers_report(self, mock_delay, user, psych_q):
+        from questionnaires.serializers import ResponseSetSubmitSerializer
+
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_q, status='DRAFT', milestone='1_YEAR',
+        )
+        data = {'responses_data': []}
+        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        mock_delay.assert_called_once_with(str(rs.id), '1_YEAR')
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    def test_7days_completion_does_not_trigger_report(self, mock_delay, user, psych_q):
+        from questionnaires.serializers import ResponseSetSubmitSerializer
+
+        rs = ResponseSet.objects.create(
+            user=user, questionnaire=psych_q, status='DRAFT', milestone='7_DAYS',
+        )
+        data = {'responses_data': []}
+        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        mock_delay.assert_not_called()
+
+    @patch('questionnaires.tasks.send_perma_snapshot_report_task.delay')
+    @patch('groups.services.assign_user_to_group')
+    def test_sociodemographic_completion_does_not_trigger_report(
+        self, mock_assign, mock_delay, db, participant_role
+    ):
+        from questionnaires.serializers import ResponseSetSubmitSerializer
+
+        socio_q = Questionnaire.objects.create(
+            title='Sociodemographic Survey', assessment_type='SOCIODEMOGRAPHIC', is_active=True,
+        )
+        u = User.objects.create_user(
+            username='socio_trig_user', email='s@test.com', password='pw',
+            role=participant_role,
+        )
+        rs = ResponseSet.objects.create(
+            user=u, questionnaire=socio_q, status='DRAFT', milestone='SIGNUP',
+        )
+        data = {'responses_data': []}
+        serializer = ResponseSetSubmitSerializer(instance=rs, data=data)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        mock_delay.assert_not_called()

--- a/backend/questionnaires/tests/test_seeding.py
+++ b/backend/questionnaires/tests/test_seeding.py
@@ -42,6 +42,57 @@ def test_seed_longitudinal_scales_command_success(db):
                 scale_order.append(group)
     assert scale_order == ['PERMA', 'PHQ-9', 'GAD-7', 'PANAS', 'Gratitude', 'SIDAS']
 
+    # Verify exact option counts — guards against stale options from scale reassignment
+    # PERMA (0-10): 11 options each; PHQ-9 / GAD-7 (0-3): 4 each;
+    # PANAS (0-4): 5 each; Gratitude (0-4): 5 each; SIDAS (0-10): 11 each
+    scale_expected_options = {
+        'PERMA': 11, 'PHQ-9': 4, 'GAD-7': 4, 'PANAS': 5, 'Gratitude': 5, 'SIDAS': 11,
+    }
+    for q in questions:
+        if q.type == 'TEXT':
+            continue
+        if q.content.startswith('[') and ']' in q.content:
+            group = q.content[1:q.content.index(']')]
+            expected = scale_expected_options.get(group)
+            if expected is not None:
+                actual = Option.objects.filter(question=q).count()
+                assert actual == expected, (
+                    f"Question order={q.order} [{group}] has {actual} options, expected {expected}. "
+                    "Stale options from a prior scale reassignment may not have been pruned."
+                )
+
+@pytest.mark.django_db
+def test_seed_prunes_stale_options_on_reseed(db):
+    """
+    Regression: Gratitude items 24-26 (orders 75-77) previously inherited 0-10
+    SIDAS options after an order-shift migration. Re-seeding must prune the extra
+    options so each Gratitude question ends up with exactly 5 options (0-4).
+    """
+    from questionnaires.models import Option as Opt
+
+    call_command('seed_longitudinal_scales')
+
+    battery = Questionnaire.objects.get(title="Longitudinal Psychometric Scales")
+
+    # Manually inject stale 0-10 SIDAS-style options onto Gratitude items 24-26
+    # (orders 75, 76, 77) to reproduce the bug.
+    grat_tail_orders = [75, 76, 77]
+    for order in grat_tail_orders:
+        q = Question.objects.get(questionnaire=battery, order=order)
+        for v in range(5, 11):  # values 5-10 are stale
+            Opt.objects.get_or_create(question=q, numeric_value=v, defaults={"label": str(v), "order": v})
+        assert Opt.objects.filter(question=q).count() == 11  # 0-10 = bug state
+
+    # Re-seeding must prune the stale options back to exactly 5 (0-4)
+    call_command('seed_longitudinal_scales')
+    for order in grat_tail_orders:
+        q = Question.objects.get(questionnaire=battery, order=order)
+        actual = Opt.objects.filter(question=q).count()
+        assert actual == 5, (
+            f"Gratitude order={order} still has {actual} options after reseed; expected 5 (0-4)."
+        )
+
+
 @pytest.mark.django_db
 def test_seed_longitudinal_scales_is_idempotent(db):
     """

--- a/backend/questionnaires/tests/test_signup_screen_out.py
+++ b/backend/questionnaires/tests/test_signup_screen_out.py
@@ -73,10 +73,12 @@ def test_signup_risk_sends_support_and_welcome_not_disqualified(fresh_client, fr
     assert fresh_user.is_disqualified is False
     assert fresh_user.onboarding_completed_at is not None
 
-    assert len(mail.outbox) == 2
+    # Support email + welcome email + PERMA baseline report = 3
+    assert len(mail.outbox) == 3
     subjects = [message.subject for message in mail.outbox]
     assert any('Support resources are available' in subject for subject in subjects)
     assert any('Welcome to Psycheversity' in subject for subject in subjects)
+    assert any('baseline' in subject.lower() for subject in subjects)
     assert Notification.objects.filter(user=fresh_user, n_type='email').count() == 0
 
 
@@ -148,8 +150,9 @@ def test_signup_draft_to_submit_sends_participant_email(fresh_client, fresh_user
     )
     assert response.status_code == status.HTTP_200_OK
     
-    # Verify both the support and welcome email are sent
-    assert len(mail.outbox) == 2
+    # Support email + welcome email + PERMA baseline report = 3
+    assert len(mail.outbox) == 3
     subjects = [message.subject for message in mail.outbox]
     assert any('Support resources are available' in subject for subject in subjects)
     assert any('Welcome to Psycheversity' in subject for subject in subjects)
+    assert any('baseline' in subject.lower() for subject in subjects)

--- a/deploy_configs/deploy.py
+++ b/deploy_configs/deploy.py
@@ -171,6 +171,11 @@ def main():
         seed_activities_cmd = f"cd {REMOTE_DIR} && docker compose exec -T backend python manage.py seed_daily_tasks"
         run_ssh_command(ssh, seed_activities_cmd)
 
+        # 11. Backfill PERMA baseline reports for pre-feature T0 completions
+        print("\n=== Dispatching missing PERMA baseline reports (pre-feature T0 users) ===")
+        backfill_cmd = f"cd {REMOTE_DIR} && docker compose exec -T backend python manage.py send_missing_signup_reports"
+        run_ssh_command(ssh, backfill_cmd)
+
         print("\n=== DEPLOYMENT COMPLETED SUCCESSFULY ===")
         print(f"Service running at: http://{VM_HOST}:{4756}")
         

--- a/frontend/src/pages/QuestionnairePage.tsx
+++ b/frontend/src/pages/QuestionnairePage.tsx
@@ -666,6 +666,31 @@ const QuestionnairePage: React.FC = () => {
           className="space-y-12"
         >
           <div className="space-y-8">
+            {/* Gratitude Response Key — stem + bilingual legend (no separate TEXT header in DB) */}
+            {currentScaleGroup.name === 'Gratitude' && (
+              <div className="border border-zinc-200 rounded-xl p-5 md:p-6 bg-zinc-50/80 shadow-sm space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pb-3 border-b border-zinc-200">
+                  <p className="text-sm font-medium text-zinc-700 leading-relaxed">Please indicate how strongly you agree with each statement.</p>
+                  <p className="text-sm font-medium text-zinc-700 leading-relaxed font-urdu text-right" dir="rtl">براہ کرم نشاندہی کیجیے کہ آپ ہر بیان سے کس حد تک متفق ہیں۔</p>
+                </div>
+                <div className="text-xs font-bold text-zinc-500 uppercase tracking-wider">Response Key / جوابات کی کنجی</div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+                  {[
+                    { val: 0, en: 'Completely disagree', ur: 'بالکل غیر متفق' },
+                    { val: 1, en: 'Disagree', ur: 'غیر متفق' },
+                    { val: 2, en: 'Neutral', ur: 'غیر جانبدار' },
+                    { val: 3, en: 'Agree', ur: 'متفق' },
+                    { val: 4, en: 'Completely agree', ur: 'مکمل متفق' },
+                  ].map((anchor) => (
+                    <div key={anchor.val} className="flex flex-col items-center text-center border border-zinc-200 rounded-lg bg-white px-2 py-3 gap-1">
+                      <span className="text-lg font-bold text-zinc-700">{anchor.val}</span>
+                      <span className="text-[11px] font-medium text-zinc-600 leading-tight">{anchor.en}</span>
+                      <span className="text-[11px] font-medium text-zinc-500 font-urdu leading-tight" dir="rtl">{anchor.ur}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             {currentScaleGroup.questions.map((question: any, idx: number) => {
               if (currentScaleGroup.name === 'SIDAS' && idx > 0) {
                 const firstSidasQ = currentScaleGroup.questions[0];
@@ -674,6 +699,75 @@ const QuestionnairePage: React.FC = () => {
                 }
               }
               const { english, urdu } = splitQuestionContent(question.content);
+
+              // Non-required TEXT questions are section headers / instructions.
+              // Render stem banner first, then the response key directly below it
+              // so the one-liner always sits above the key (not the other way around).
+              if (question.type === 'TEXT' && !question.required) {
+                const isPhqGad = currentScaleGroup.name === 'PHQ-9' || currentScaleGroup.name === 'GAD-7';
+                const isPanas = currentScaleGroup.name === 'PANAS';
+                return (
+                  <React.Fragment key={question.id}>
+                    <div className="border border-zinc-200 rounded-xl p-5 md:p-6 bg-gradient-to-br from-zinc-50 to-white shadow-sm">
+                      {urdu ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+                          <div className="text-left">
+                            <p className="text-sm md:text-base font-medium text-zinc-700 leading-relaxed">{english}</p>
+                          </div>
+                          <div className="text-right" dir="rtl">
+                            <p className="text-sm md:text-base font-medium text-zinc-700 leading-relaxed font-urdu">{urdu}</p>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-sm md:text-base font-medium text-zinc-700 leading-relaxed">{english}</p>
+                      )}
+                    </div>
+                    {/* PHQ-9 / GAD-7 response key — appears below the stem */}
+                    {isPhqGad && (
+                      <div className="border border-zinc-200 rounded-xl p-5 md:p-6 bg-zinc-50/80 shadow-sm">
+                        <div className="text-xs font-bold text-zinc-500 uppercase tracking-wider mb-3">Response Key / جوابات کی کنجی</div>
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                          {[
+                            { val: 0, en: 'Not at all', ur: 'بالکل نہیں' },
+                            { val: 1, en: 'Several days', ur: 'کئی دن' },
+                            { val: 2, en: 'More than half the days', ur: 'ایک ہفتے سے زیادہ' },
+                            { val: 3, en: 'Nearly every day', ur: 'تقریباً روزانہ' },
+                          ].map((anchor) => (
+                            <div key={anchor.val} className="flex flex-col items-center text-center border border-zinc-200 rounded-lg bg-white px-2 py-3 gap-1">
+                              <span className="text-lg font-bold text-zinc-700">{anchor.val}</span>
+                              <span className="text-[11px] font-medium text-zinc-600 leading-tight">{anchor.en}</span>
+                              <span className="text-[11px] font-medium text-zinc-500 font-urdu leading-tight" dir="rtl">{anchor.ur}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {/* PANAS response key — appears below the stem */}
+                    {isPanas && (
+                      <div className="border border-zinc-200 rounded-xl p-5 md:p-6 bg-zinc-50/80 shadow-sm">
+                        <div className="text-xs font-bold text-zinc-500 uppercase tracking-wider mb-3">Response Key / جوابات کی کنجی</div>
+                        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+                          {[
+                            { val: 0, en: 'Very slightly or not at all', ur: 'کبھی نہیں' },
+                            { val: 1, en: 'A little', ur: 'بہت کم' },
+                            { val: 2, en: 'Moderately', ur: 'درمیانہ' },
+                            { val: 3, en: 'Quite a bit', ur: 'کافی حد تک' },
+                            { val: 4, en: 'Extremely', ur: 'بہت زیادہ' },
+                          ].map((anchor) => (
+                            <div key={anchor.val} className="flex flex-col items-center text-center border border-zinc-200 rounded-lg bg-white px-2 py-3 gap-1">
+                              <span className="text-lg font-bold text-zinc-700">{anchor.val}</span>
+                              <span className="text-[11px] font-medium text-zinc-600 leading-tight">{anchor.en}</span>
+                              <span className="text-[11px] font-medium text-zinc-500 font-urdu leading-tight" dir="rtl">{anchor.ur}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </React.Fragment>
+                );
+              }
+
+              // Count only scorable questions (skip non-required TEXT headers) for the counter
               return (
                 <div key={question.id} className="border border-zinc-200 rounded-xl p-6 md:p-8 bg-white shadow-sm space-y-6">
                   <div className="flex justify-between items-center pb-4 border-b border-zinc-100">


### PR DESCRIPTION
## Summary

- **PERMA snapshot report**: automated PDF wellbeing report emailed to participants at SIGNUP, 3_MONTHS, and 1_YEAR milestones. Vertical bar chart (WeasyPrint), bilingual HTML template (English + Urdu via Nastaleeq font), idempotent via `PermaReportLog` audit model.
- **Backfill command**: `send_missing_signup_reports` management command dispatches baseline reports for users who completed T0 before this feature shipped; runs automatically on deploy.
- **Seeding fix**: `_sync_questions_for_questionnaire` now prunes stale options (Pass 3b) when a question scale changes — prevents option-count drift after order reassignments.
- **Questionnaire UI**: PHQ-9 / GAD-7 / PANAS response keys now render below their TEXT header questions from the DB; removed stale static response key blocks.

## Test plan

- [ ] 40 new tests in `test_perma_report.py` covering scoring, model uniqueness, task happy-path for all 3 milestones, idempotency, cron catch-up, and serializer triggers
- [ ] `test_month3_report.py` migrated to new task — 5 tests pass
- [ ] 4 existing tests updated to reflect new email count (welcome + PERMA report on SIGNUP)
- [ ] `test_seeding.py` — new regression tests for stale option pruning
- [ ] Full suite: 295 passed on remote VM post-deploy

 