### PR TITLE
fix: support button mobile overlap, modal label cleanup, landing page for logged-in users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,7 @@ const App: React.FC = () => {
             <Routes>
               <Route
                 path="/"
-                element={checkAuth() ? (isAdminUser() ? <Navigate to="/admin" replace /> : <Navigate to="/dashboard" replace />) : <LandingPage />}
+                element={<LandingPage />}
               />
 
               {/* Guest Only Routes */}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -16,7 +16,8 @@ const Navbar: React.FC = () => {
   const isAuthenticated = !!localStorage.getItem('access_token');
   const userRole = localStorage.getItem('user_role');
   const isAdmin = userRole === 'Admin';
-  const showLanguageSwitcher = isAuthenticated && !isActivityPage && !isDashboardPage;
+  const isLandingPage = location.pathname === '/';
+  const showLanguageSwitcher = isAuthenticated && !isActivityPage && !isDashboardPage && !isLandingPage;
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSupportOpen, setIsSupportOpen] = useState(false);
@@ -190,7 +191,7 @@ const Navbar: React.FC = () => {
       {isAuthenticated && !isAdmin && (
         <button
           onClick={() => setIsSupportOpen(true)}
-          className="fixed bottom-6 right-6 z-50 px-5 py-3 bg-zinc-900 text-white hover:bg-zinc-800 rounded-full shadow-2xl hover:shadow-zinc-900/30 transition-all duration-300 hover:scale-105 flex items-center gap-2 border border-zinc-700/50 animate-in fade-in zoom-in-95 duration-300 font-semibold text-sm"
+          className="fixed bottom-6 left-6 sm:left-auto sm:right-6 z-50 px-5 py-3 bg-zinc-900 text-white hover:bg-zinc-800 rounded-full shadow-2xl hover:shadow-zinc-900/30 transition-all duration-300 hover:scale-105 flex items-center gap-2 border border-zinc-700/50 animate-in fade-in zoom-in-95 duration-300 font-semibold text-sm"
           title="Support / رابطہ"
         >
           <HelpCircle size={18} />

--- a/frontend/src/components/SupportModal.tsx
+++ b/frontend/src/components/SupportModal.tsx
@@ -148,8 +148,8 @@ const SupportModal: React.FC<SupportModalProps> = ({ isOpen, onClose }) => {
                   )}
                   <div className="space-y-1.5">
                     <label className="text-sm font-medium text-zinc-700 flex justify-between">
-                      <span>Subject (English)</span>
-                      <span className="font-urdu text-zinc-500" dir="rtl">موضوع (اردو)</span>
+                      <span>Subject</span>
+                      <span className="font-urdu text-zinc-500" dir="rtl">موضوع</span>
                     </label>
                     <input
                       type="text"
@@ -163,8 +163,8 @@ const SupportModal: React.FC<SupportModalProps> = ({ isOpen, onClose }) => {
                   </div>
                   <div className="space-y-1.5">
                     <label className="text-sm font-medium text-zinc-700 flex justify-between">
-                      <span>Message (English)</span>
-                      <span className="font-urdu text-zinc-500" dir="rtl">پیغام (اردو)</span>
+                      <span>Message</span>
+                      <span className="font-urdu text-zinc-500" dir="rtl">پیغام</span>
                     </label>
                     <textarea
                       required


### PR DESCRIPTION
## Summary
- **Support button mobile overlap**: Moved the Support/مدد FAB to `bottom-left` on mobile (`sm:` and up stays bottom-right), so it no longer overlaps the questionnaire Continue/Submit button
- **SupportModal label cleanup**: Removed redundant "(English)" and "(Urdu)" annotations from Subject and Message field labels — labels now show just `Subject / موضوع` and `Message / پیغام`
- **Landing page access for logged-in users**: Route `/` now renders `LandingPage` for all users instead of redirecting authenticated users away; language switcher is hidden on the landing page to keep the UI clean

## Test plan
- [x] On mobile, open a questionnaire — Support button should appear bottom-left, Continue button bottom-right with no overlap
- [ ] Open Support Center modal → New Ticket tab — field labels should read "Subject / موضوع" and "Message / پیغام" with no language annotations
- [ ] While logged in, click the Psycheversity logo — landing page should load (not redirect to dashboard)
- [ ] Language switcher should not appear on the landing page when logged in

 